### PR TITLE
unwrap response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "0.0.29",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "0.0.29",
+      "version": "0.0.35",
       "license": "MIT",
       "dependencies": {
         "@insforge/shared-schemas": "^1.0.7",

--- a/src/modules/database-postgrest.ts
+++ b/src/modules/database-postgrest.ts
@@ -37,11 +37,50 @@ function createInsForgePostgrestFetch(
     }
     
     // Make the actual request using native fetch
-    // This returns a proper Response object with headers
     const response = await fetch(insforgeUrl, {
       ...init,
       headers
     });
+    
+    // RESPONSE TRANSFORMATION FOR POSTGREST-JS COMPATIBILITY
+    // 
+    // Backend returns (wrapped):
+    // {
+    //   data: [{id: 1}, {id: 2}],        // The actual rows
+    //   pagination: {                     // Pagination metadata
+    //     offset: 0,
+    //     limit: 10,
+    //     total: 100
+    //   }
+    // }
+    // Headers: Content-Range: 0-9/100
+    //
+    // PostgREST-js expects (unwrapped):
+    // [{id: 1}, {id: 2}]                  // Just the array
+    // Headers: Content-Range: 0-9/100     // Pagination in header
+    //
+    // We unwrap only for GET requests (SELECT queries)
+    if (response.ok && (!init?.method || init.method === 'GET')) {
+      try {
+        // Clone to read body without consuming original
+        const body = await response.clone().json();
+        
+        // Check if backend wrapped the response
+        if (body?.data && body?.pagination) {
+          return new Response(
+            JSON.stringify(body.data),
+            {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers
+            }
+          );
+        }
+      } catch {
+        // Not JSON or parsing failed, return original
+        // This handles non-JSON responses, errors, etc.
+      }
+    }
     
     return response;
   };


### PR DESCRIPTION
After https://github.com/InsForge/InsForge/pull/224, the database structure have been changed. Thus we need to change the reponse of our SDK to make sure nothing breaks


The other dataformat changes are for admin endpoitns, those endpoitns are not covered in SDK yet. SDK is only for client side changes not used for any admin changes


test: