### PR TITLE
fix(ci): skip email step when mail secrets are not configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
             echo "COVERAGE=Coverage report not generated" >> $GITHUB_OUTPUT
           fi
       - name: Email coverage report to maintainer
-        if: matrix.node-version == 20 && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: matrix.node-version == 20 && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.MAIL_SMTP_HOST != ''
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: ${{ secrets.MAIL_SMTP_HOST }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,10 @@ jobs:
             echo "COVERAGE=Coverage report not generated" >> $GITHUB_OUTPUT
           fi
       - name: Email coverage report to maintainer
-        if: matrix.node-version == 20 && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.MAIL_SMTP_HOST != ''
+        if: matrix.node-version == 20 && github.event_name == 'push' && github.ref == 'refs/heads/main' && env.MAIL_SMTP_HOST != ''
         uses: dawidd6/action-send-mail@v3
+        env:
+          MAIL_SMTP_HOST: ${{ secrets.MAIL_SMTP_HOST }}
         with:
           server_address: ${{ secrets.MAIL_SMTP_HOST }}
           server_port: ${{ secrets.MAIL_SMTP_PORT }}


### PR DESCRIPTION
## Summary
- CI email step (`dawidd6/action-send-mail@v3`) fails on main when `MAIL_SMTP_HOST` secret is not set, marking the entire workflow as failed
- Added guard condition `secrets.MAIL_SMTP_HOST != ''` so the step is skipped when mail secrets are absent

## Test plan
- [ ] Push to main and verify CI passes without mail secrets configured
- [ ] Once mail secrets are added, verify coverage emails are sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip email coverage report step when `MAIL_SMTP_HOST` secret is not configured
> The 'Email coverage report to maintainer' step in [ci.yml](.github/workflows/ci.yml) now checks that `MAIL_SMTP_HOST` is set and non-empty before running. The secret is also explicitly exposed to the step's environment so the condition can evaluate it correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f94775a. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated so coverage reports are emailed only when mail server configuration is present, preventing failed or unintended sends.
  * This change improves automation reliability and avoids noisy failures when email settings are not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->