### PR TITLE
fix(auth): auto-enable server mode when edgeFunctionToken is set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -77,7 +77,7 @@ export class InsForgeClient {
     }
 
     this.auth = new Auth(this.http, this.tokenManager, {
-      isServerMode: config.isServerMode ?? false,
+      isServerMode: config.isServerMode ?? !!config.edgeFunctionToken,
     });
     this.database = new Database(this.http, this.tokenManager);
     this.storage = new Storage(this.http);

--- a/src/lib/__tests__/client.test.ts
+++ b/src/lib/__tests__/client.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { InsForgeClient } from '../../client';
+
+describe('InsForgeClient – edgeFunctionToken implies server mode', () => {
+  it('should auto-enable server mode when edgeFunctionToken is provided', async () => {
+    const fakeToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test';
+    const client = new InsForgeClient({
+      baseUrl: 'http://localhost:7130',
+      edgeFunctionToken: fakeToken,
+    });
+
+    // getCurrentUser() should take the server path (calls /api/auth/sessions/current)
+    // rather than the browser path (checks session memory, tries cookie refresh).
+    // Without the fix, this would silently return { user: null } because the browser
+    // path finds no session and skips the cookie refresh (no window in Node).
+    // With the fix, it hits the server endpoint — which will fail with a network error
+    // since localhost:7130 isn't running, proving it took the server code path.
+    const { data, error } = await client.auth.getCurrentUser();
+
+    // In server mode with a token, the SDK attempts a network call to /api/auth/sessions/current.
+    // Since there's no server, we expect an error (network/connection error), NOT a silent { user: null }.
+    // A silent null user with no error would mean it took the browser path — the bug.
+    expect(error).not.toBeNull();
+  });
+
+  it('should respect explicit isServerMode: false even with edgeFunctionToken', async () => {
+    const fakeToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test';
+    const client = new InsForgeClient({
+      baseUrl: 'http://localhost:7130',
+      edgeFunctionToken: fakeToken,
+      isServerMode: false,
+    });
+
+    // Explicit false overrides the auto-detection — browser path, silent null
+    const { data, error } = await client.auth.getCurrentUser();
+    expect(data.user).toBeNull();
+    expect(error).toBeNull();
+  });
+
+  it('should default to browser mode when no edgeFunctionToken is provided', async () => {
+    const client = new InsForgeClient({
+      baseUrl: 'http://localhost:7130',
+    });
+
+    // No token, no server mode — browser path returns silent null
+    const { data, error } = await client.auth.getCurrentUser();
+    expect(data.user).toBeNull();
+    expect(error).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  ssr: {
+    noExternal: ['@insforge/shared-schemas'],
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

- `getCurrentUser()` silently returns `{ user: null }` in edge functions because the SDK defaults to browser mode even when `edgeFunctionToken` is provided
- **Fix:** `isServerMode` now defaults to `true` when `edgeFunctionToken` is set (`config.isServerMode ?? !!config.edgeFunctionToken`)
- Explicit `isServerMode: false` still overrides if needed — no breaking change
- Added `vitest.config.ts` fix for `@insforge/shared-schemas` so unit tests importing the full client work

## What was happening

Users creating edge functions with `edgeFunctionToken` expected `getCurrentUser()` to work. Instead it took the browser code path (no cookies/localStorage in edge runtime), silently returned null, and gave no error — making it very hard to debug.

## Tests added

- ✅ `edgeFunctionToken` auto-enables server mode → `getCurrentUser()` hits server endpoint
- ✅ Explicit `isServerMode: false` still overrides (backward compat)
- ✅ No `edgeFunctionToken` → stays in browser mode (default preserved)

All 56 tests pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-enable server mode in `InsForgeClient` when `edgeFunctionToken` is set
> Previously, `isServerMode` defaulted to `false` unless explicitly set. Now, providing an `edgeFunctionToken` in the config implicitly sets `isServerMode` to `true`, while an explicit `isServerMode: false` still overrides it. Tests covering the new defaulting behavior are added in [client.test.ts](https://github.com/InsForge/InsForge-sdk-js/pull/63/files#diff-20c760191b812fc2a6840aaf13ee15431c391f9f57bda095a9cbd3c3b4ec3ef8).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #63 opened
>
> - Bumped package version from 1.2.3 to 1.2.4 [ef01b87]
> - Updated package lockfile [ef01b87]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7356df0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client now auto-enables server mode when an edge function token is present (unless explicitly overridden).

* **Tests**
  * Added tests covering authentication mode selection and expected behaviors across scenarios.

* **Chores**
  * Adjusted test runner SSR handling for a specific dependency and bumped package version to 1.2.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->