### PR TITLE
feat(client): expose public setAccessToken() for third-party auth bridges

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -105,6 +105,38 @@ export class InsForgeClient {
   }
 
   /**
+   * Set the access token used by every SDK surface. Updates both the HTTP
+   * client (database / storage / functions / AI / emails) and the realtime
+   * token manager (which fires `onTokenChange` to reconnect the WebSocket
+   * with the new bearer). Pass `null` to clear.
+   *
+   * Use this when an external auth provider (Better Auth, Clerk, Auth0,
+   * WorkOS, Kinde, Stytch, …) issues the JWT and you need to keep the
+   * long-lived InsForge client in sync. Without this, you'd have to call
+   * `client.getHttpClient().setAuthToken(token)` AND reach into the private
+   * `client.realtime.tokenManager.setAccessToken(token)` separately —
+   * forgetting the second one silently breaks realtime auth.
+   *
+   * @example
+   * ```typescript
+   * // Refresh a third-party-issued JWT periodically
+   * const { token } = await fetch('/api/insforge-token').then((r) => r.json());
+   * client.setAccessToken(token);
+   *
+   * // Sign-out
+   * client.setAccessToken(null);
+   * ```
+   */
+  setAccessToken(token: string | null): void {
+    this.http.setAuthToken(token);
+    if (token === null) {
+      this.tokenManager.clearSession();
+    } else {
+      this.tokenManager.setAccessToken(token);
+    }
+  }
+
+  /**
    * Future modules will be added here:
    * - database: Database operations
    * - storage: File storage operations

--- a/src/lib/__tests__/client.test.ts
+++ b/src/lib/__tests__/client.test.ts
@@ -48,3 +48,41 @@ describe('InsForgeClient – edgeFunctionToken implies server mode', () => {
     expect(error).toBeNull();
   });
 });
+
+describe('InsForgeClient.setAccessToken', () => {
+  it('fires onTokenChange on every transition (string → string → null)', () => {
+    const client = new InsForgeClient({ baseUrl: 'http://localhost:7130' });
+
+    // Replace realtime's tokenManager handler with a counting probe so we can
+    // observe that the realtime path is being notified — this is what callers
+    // had to verify by hand before this method existed.
+    let count = 0;
+    // @ts-expect-error: tokenManager is private at compile-time; reaching in for the test
+    client.tokenManager.onTokenChange = () => { count++; };
+
+    client.setAccessToken('token-a');
+    expect(count).toBe(1);
+
+    client.setAccessToken('token-b');
+    expect(count).toBe(2);
+
+    client.setAccessToken(null);
+    expect(count).toBe(3);
+  });
+
+  it('does not fire when token is unchanged', () => {
+    const client = new InsForgeClient({ baseUrl: 'http://localhost:7130' });
+    let count = 0;
+    // @ts-expect-error: tokenManager is private at compile-time; reaching in for the test
+    client.tokenManager.onTokenChange = () => { count++; };
+
+    client.setAccessToken('same');
+    client.setAccessToken('same');
+    expect(count).toBe(1);
+
+    // Clearing when already null is also a no-op
+    client.setAccessToken(null);
+    client.setAccessToken(null);
+    expect(count).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `InsForgeClient.setAccessToken(token: string | null)` so external auth providers (Clerk, Auth0, WorkOS, Kinde, Stytch, Better Auth) can keep a long-lived InsForge client in sync without reaching into private state.

## The problem

Every third-party-auth integration today carries this:

```ts
function setBridgeToken(client: InsForgeClient, token: string | null) {
  client.getHttpClient().setAuthToken(token);
  // @ts-expect-error: tokenManager is private at compile-time, accessible at runtime
  client.realtime.tokenManager.setAccessToken(token);
}
```

`getHttpClient().setAuthToken()` only updates HTTP; realtime's `TokenManager` has its own copy. Forgetting the second call silently breaks realtime auth — `senderId` shows as the anon UUID instead of the user's id, and the only signal is "publish silently fails" (this exact pitfall is documented as the last "Common Mistakes" row of the Better Auth integration skill).

## The fix

The dual-set pattern is already used internally **four times** — the constructor's `edgeFunctionToken` path (`src/client.ts:75-76`), `Auth.signIn` (`src/modules/auth/auth.ts:90,92`), `Auth.signOut` (`src/modules/auth/auth.ts:203-204`), and the auto-refresh path (`src/modules/auth/auth.ts:441-444, 453-455`). This PR just exposes it as a public method:

```ts
setAccessToken(token: string | null): void {
  this.http.setAuthToken(token);
  if (token === null) {
    this.tokenManager.clearSession();
  } else {
    this.tokenManager.setAccessToken(token);
  }
}
```

After this, integration code becomes one call:

```ts
client.setAccessToken(token);   // sign-in / refresh
client.setAccessToken(null);    // sign-out
```

No `@ts-expect-error`, no private-API access, realtime re-auths automatically via the existing `onTokenChange` callback.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes; `setAccessToken(token: string | null): void` lands in the public `dist/index.d.ts`
- [x] `npx vitest run` — 58/58 tests pass (3 files: logger, http-client, client)
- [x] New unit tests cover (a) `onTokenChange` fires on every transition (string → string → null), and (b) it does NOT fire on identity transitions
- [x] End-to-end verified against the Better Auth + InsForge skill's runnable skeleton — packed the SDK, installed it, replaced the workaround with `client.setAccessToken(token)`, ran the 12-check e2e (signup → bridge JWT → RLS-isolated CRUD → REVOKE → sign-out): **12/12 pass**

## Notes for reviewers

- Pure addition — no existing call sites changed, no exports renamed.
- `setAccessToken(null)` routes through `tokenManager.clearSession()` (drops the `user` too, not just the token), matching `Auth.signOut`'s semantics.
- The two `@ts-expect-error tokenManager` comments in the new tests are intentional — the tests are *verifying* the implementation's side effects on a private field, which is a reasonable thing for tests to do; production callers no longer need to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new token management capability to synchronize access tokens across all SDK surfaces. You can now update authentication tokens or clear them as needed, ensuring consistent authentication throughout the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->