### PR TITLE
Fix refresh error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.52",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/lib/__tests__/http-client.test.ts
+++ b/src/lib/__tests__/http-client.test.ts
@@ -987,6 +987,35 @@ describe('HttpClient', () => {
       expect(tokenManager.clearSession).toHaveBeenCalledOnce();
     });
 
+    it('should preserve session when refresh fails with a transient network error', async () => {
+      const tokenManager = createMockTokenManager();
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          createJsonResponse(
+            401,
+            {
+              error: 'AUTH_UNAUTHORIZED',
+              message: 'Invalid token',
+              statusCode: 401,
+            },
+            'Unauthorized',
+          ),
+        )
+        .mockRejectedValueOnce(new TypeError('network down'));
+
+      const client = createClient(mockFetch, {}, tokenManager);
+      client.setAuthToken('old-token');
+      const error = (await client
+        .get('/api/protected')
+        .catch((e: unknown) => e)) as InsForgeError;
+
+      expect(error).toBeInstanceOf(InsForgeError);
+      expect(error.error).toBe('NETWORK_ERROR');
+      expect(tokenManager.clearSession).not.toHaveBeenCalled();
+      expect(client.getHeaders().Authorization).toBe('Bearer old-token');
+    });
+
     it('refresh succeeds, retry fails without clearing auth state', async () => {
       const tokenManager = createMockTokenManager();
       const mockFetch = vi

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -518,7 +518,12 @@ export class HttpClient {
       try {
         await this.refreshAndSaveSession();
       } catch (error) {
-        this.clearAuthSession();
+        if (
+          error instanceof InsForgeError &&
+          (error.statusCode === 401 || error.statusCode === 403)
+        ) {
+          this.clearAuthSession();
+        }
         throw error;
       }
       return await this.handleRequest<T>(method, path, {
@@ -649,7 +654,12 @@ export class HttpClient {
     try {
       newTokenData = await this.refreshAndSaveSession();
     } catch (error) {
-      this.clearAuthSession();
+      if (
+        error instanceof InsForgeError &&
+        (error.statusCode === 401 || error.statusCode === 403)
+      ) {
+        this.clearAuthSession();
+      }
       throw error;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes token refresh flow to preserve the current session on transient errors, preventing unwanted logouts. Auth is only cleared when refresh fails with 401/403.

- Bug Fixes
  - Clear auth only when refresh throws `InsForgeError` with 401 or 403; keep session for network errors.
  - Added a test to ensure session is preserved when refresh fails due to a network error.

- Dependencies
  - Bump `@insforge/sdk` to `1.2.10`.

<sup>Written for commit fb7803d18b4bb4ea7d7a18b8e7634fb6d3358335. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/71?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.2.10

* **Bug Fixes**
  * Auth session is now preserved on transient network errors during token refresh; only cleared on authentication failures.

* **Tests**
  * Added coverage for token refresh behavior during network failures.

* **Chores**
  * Version bumped to 1.2.10.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge-sdk-js/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix session clearing in `HttpClient` when token refresh fails with a non-auth error
> When a 401/403 response triggers a token refresh and the refresh fails (e.g., due to a network error), the client previously always cleared the auth session. Now, `clearAuthSession` is only called if the refresh fails with a 401 or 403; other errors rethrow without clearing the session, preserving existing tokens.
>
> This affects both `handleRequest` and `rawFetch` in [http-client.ts](https://github.com/InsForge/InsForge-sdk-js/pull/71/files#diff-c15a8f720fb13adf8a92b21adb9ad29c2169a8ffea3df727a03a5728ca164e96).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb7803d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->