### PR TITLE
refactor(auth): trigger token refresh via HTTP 401 semantics instead of error-code matching

### DIFF
--- a/docs/superpowers/plans/2026-04-15-functions-in-process-dispatch.md
+++ b/docs/superpowers/plans/2026-04-15-functions-in-process-dispatch.md
@@ -233,11 +233,11 @@ describe('parseResponse', () => {
       status: 400,
       statusText: 'Bad Request',
       contentType: 'application/json',
-      jsonValue: { error: 'INVALID_INPUT', message: 'name required' },
+      jsonValue: { error: 'PAYMENT_CONFIG_INVALID', message: 'name required' },
     });
     await expect(parseResponse(res)).rejects.toMatchObject({
       statusCode: 400,
-      error: 'INVALID_INPUT',
+      error: 'PAYMENT_CONFIG_INVALID',
       message: 'name required',
     });
   });
@@ -522,7 +522,7 @@ describe('Functions.invoke', () => {
     it('falls back to proxy when subhosting returns 404', async () => {
       const fetchFn = vi
         .fn()
-        .mockResolvedValueOnce(jsonRes(404, { error: 'NOT_FOUND', message: 'no' }, 'Not Found'))
+        .mockResolvedValueOnce(jsonRes(404, { error: 'DEPLOYMENT_NOT_FOUND', message: 'no' }, 'Not Found'))
         .mockResolvedValueOnce(jsonRes(200, { proxied: true }));
       const http = makeHttp(fetchFn);
       const fns = new Functions(http, 'https://app.functions.insforge.app');

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -24,10 +24,7 @@ export interface RequestOptions extends Omit<RequestInit, 'body'> {
 
 const RETRYABLE_STATUS_CODES = new Set([500, 502, 503, 504]);
 const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS']);
-const REFRESHABLE_AUTH_ERROR_CODES = new Set([
-  'AUTH_UNAUTHORIZED',
-  'PGRST301',
-]);
+
 
 /**
  * Serialize a request body into something fetch (or a Request constructor) accepts.
@@ -203,13 +200,11 @@ export class HttpClient {
 
   private shouldRefreshAccessToken(
     statusCode: number,
-    errorCode: string | null | undefined,
     authToken: string | null,
     options: { skipAuthRefresh?: boolean } = {},
   ): boolean {
     return (
       statusCode === 401 &&
-      REFRESHABLE_AUTH_ERROR_CODES.has(errorCode ?? '') &&
       !this.config.isServerMode &&
       !this.config.edgeFunctionToken &&
       !options.skipAuthRefresh &&
@@ -492,7 +487,6 @@ export class HttpClient {
         !(error instanceof InsForgeError) ||
         !this.shouldRefreshAccessToken(
           error.statusCode,
-          error.error,
           tokenUsed,
           options,
         )
@@ -604,27 +598,9 @@ export class HttpClient {
       Date.now() - startTime,
     );
 
-    let errorCode: string | null = null;
-    if (response.status === 401) {
-      try {
-        const data = await response.clone().json();
-        if (data && typeof data === 'object') {
-          const candidate =
-            (data as { error?: unknown; code?: unknown }).error ??
-            (data as { code?: unknown }).code;
-          if (typeof candidate === 'string') {
-            errorCode = candidate;
-          }
-        }
-      } catch {
-        // Return the original response when the body is not JSON.
-      }
-    }
-
     if (
       !this.shouldRefreshAccessToken(
         response.status,
-        errorCode,
         tokenUsed,
         options,
       )

--- a/src/modules/__tests__/functions.test.ts
+++ b/src/modules/__tests__/functions.test.ts
@@ -71,7 +71,7 @@ describe('Functions.invoke', () => {
     it('falls back to proxy when subhosting returns 404', async () => {
       const fetchFn = vi
         .fn()
-        .mockResolvedValueOnce(jsonRes(404, { error: 'NOT_FOUND', message: 'no' }, 'Not Found'))
+        .mockResolvedValueOnce(jsonRes(404, { error: 'DEPLOYMENT_NOT_FOUND', message: 'no' }, 'Not Found'))
         .mockResolvedValueOnce(jsonRes(200, { proxied: true }));
       const http = makeHttp(fetchFn);
       const fns = new Functions(http, 'https://app.functions.insforge.app');

--- a/src/modules/__tests__/payments.test.ts
+++ b/src/modules/__tests__/payments.test.ts
@@ -115,7 +115,7 @@ describe("Payments", () => {
       .mockResolvedValue(
         jsonRes(
           400,
-          { error: "INVALID_INPUT", message: "Bad checkout" },
+          { error: "PAYMENT_CONFIG_INVALID", message: "Bad checkout" },
           "Bad",
         ),
       );
@@ -130,7 +130,7 @@ describe("Payments", () => {
 
     expect(result.data).toBeNull();
     expect(result.error).toBeInstanceOf(InsForgeError);
-    expect(result.error?.error).toBe("INVALID_INPUT");
+    expect(result.error?.error).toBe("PAYMENT_CONFIG_INVALID");
     expect(result.error?.message).toBe("Bad checkout");
   });
 


### PR DESCRIPTION
## Summary

This PR removes the SDK’s fragile coupling to backend-specific error-code strings (`AUTH_UNAUTHORIZED`, `PGRST301`) for auth recovery, shifting refresh retry gating entirely to standard HTTP `401 Unauthorized` semantics.

## Background

A recent downstream compatibility audit revealed that the SDK’s auth retry behavior depended on exact string matching against a whitelist (`REFRESHABLE_AUTH_ERROR_CODES`).

As the backend API continues migrating toward domain-specific error codes (for example, `DEPLOYMENT_NOT_FOUND` and `PAYMENT_CONFIG_INVALID`) instead of legacy shared codes (`NOT_FOUND`, `INVALID_INPUT`), this implementation introduced a production risk: refresh loops could silently stop working whenever a new specialized `401` error code was returned but not explicitly whitelisted.

## Changes

### `http-client.ts`

- Removed the `REFRESHABLE_AUTH_ERROR_CODES` configuration.
- Refactored `shouldRefreshAccessToken` to rely exclusively on `statusCode === 401`.
- Preserved existing bypass conditions such as `skipAuthRefresh`.

### `rawFetch`

- Removed unnecessary `error.code` parsing from the auth refresh gatekeeping pipeline.
- Simplified refresh retry evaluation logic.

### Fixtures & Documentation

- Updated test fixtures and assertions to use:
  - `DEPLOYMENT_NOT_FOUND`
  - `PAYMENT_CONFIG_INVALID`
- Replaced deprecated:
  - `NOT_FOUND`
  - `INVALID_INPUT`
- Updated references in:
  - `2026-04-15-functions-in-process-dispatch.md`

These changes align the SDK with the backend’s ongoing transition to domain-scoped error codes while ensuring auth recovery behavior remains stable and backend-agnostic.

Related: InsForge/InsForge#1266

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches auth token refresh to use standard HTTP 401 checks instead of matching backend error-code strings. This makes refresh logic backend-agnostic and resilient to new domain-specific error codes.

- **Refactors**
  - Removed the refresh error-code whitelist; `shouldRefreshAccessToken` now gates solely on 401 and existing bypass flags.
  - Simplified `rawFetch` by dropping `error.code` parsing and streamlining retry evaluation.
  - Updated tests/docs to new domain codes: `DEPLOYMENT_NOT_FOUND`, `PAYMENT_CONFIG_INVALID`.

<sup>Written for commit 37442d1e46bea7839eaf26c5722765a553c2dfd7. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/72?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger token refresh on any HTTP 401 instead of matching specific error codes
> - Removes `REFRESHABLE_AUTH_ERROR_CODES` from [http-client.ts](https://github.com/InsForge/InsForge-sdk-js/pull/72/files#diff-c15a8f720fb13adf8a92b21adb9ad29c2169a8ffea3df727a03a5728ca164e96) and drops the JSON body parsing step that extracted an error code before deciding whether to refresh.
> - `HttpClient.shouldRefreshAccessToken` now returns `true` for any 401 response that meets the existing client/context constraints (no edge token, not skipping refresh, auth token present).
> - Updates test fixtures to use more specific error codes: `DEPLOYMENT_NOT_FOUND` (was `NOT_FOUND`) and `PAYMENT_CONFIG_INVALID` (was `INVALID_INPUT`).
> - Behavioral Change: 401 responses that previously had no JSON body or a non-matching error code will now trigger a refresh attempt where they did not before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37442d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified authentication token refresh behavior by removing error-code inspection and relying solely on HTTP status, configuration, and token presence.

* **Tests**
  * Updated test cases to verify correct error codes are returned in payment and deployment failure scenarios.

* **Documentation**
  * Updated documentation plan examples to reflect standardized error code mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge-sdk-js/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->