### PR TITLE
fix(storage): use GET for download-strategy (with POST fallback for older backends)

### DIFF
--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -240,11 +240,29 @@ export class StorageBucket {
    */
   async download(path: string): Promise<{ data: Blob | null; error: InsForgeError | null }> {
     try {
-      // Get download strategy from backend - this is required
-      const strategyResponse = await this.http.post<DownloadStrategy>(
-        `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}/download-strategy`,
-        { expiresIn: 3600 }
-      );
+      // Get download strategy from backend - this is required.
+      // GET on the canonical path aligns with S3-style object retrieval;
+      // expiry (when presigned) is computed server-side from bucket visibility.
+      // Older backends only expose POST on the legacy path, so on a 404 from
+      // the GET endpoint fall back once to POST so the SDK keeps working
+      // against backends that haven't shipped the GET route yet.
+      const encodedKey = encodeURIComponent(path);
+      let strategyResponse: DownloadStrategy;
+      try {
+        strategyResponse = await this.http.get<DownloadStrategy>(
+          `/api/storage/buckets/${this.bucketName}/download-strategy/objects/${encodedKey}`
+        );
+      } catch (err) {
+        const status = err instanceof InsForgeError ? err.statusCode : undefined;
+        if (status === 404 || status === 405) {
+          strategyResponse = await this.http.post<DownloadStrategy>(
+            `/api/storage/buckets/${this.bucketName}/objects/${encodedKey}/download-strategy`,
+            {}
+          );
+        } else {
+          throw err;
+        }
+      }
 
       // Use URL from strategy
       const downloadUrl = strategyResponse.url;


### PR DESCRIPTION
## Summary

Pairs with the backend change in [InsForge/InsForge#1363](https://github.com/InsForge/InsForge/pull/1363). Switches `StorageBucket.download()` to call the canonical GET download-strategy endpoint:
GET /api/storage/buckets/<bucket>/download-strategy/objects/<key>



Per @Fermionic-Lyu's review on the backend PR, the SDK falls back once to the legacy POST if the GET returns `404` or `405`, so this SDK release works against:
- **new backends** (GET on the new path) — primary
- **older backends** (POST on the original path) — automatic fallback

No coordinated release required.

Refs InsForge/InsForge#1319



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use GET for object download-strategy in `StorageBucket.download()`, calling `/api/storage/buckets/<bucket>/download-strategy/objects/<key>`, with a one-time fallback to the legacy POST endpoint on 404/405. This keeps the SDK working with both new and older backends; no migration needed.

<sup>Written for commit 7b3faa49365523e4eed24c246a4531e4e58ea39a. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/74?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file download reliability through enhanced fallback mechanisms to ensure consistent performance across different storage server configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge-sdk-js/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use GET for download-strategy in `StorageBucket.download` with POST fallback for older backends
> Updates [`storage.ts`](https://github.com/InsForge/InsForge-sdk-js/pull/74/files#diff-016aa7481218cfb98625ea99a3c3875500d20acd9334c9ca78fe43c8c493d8da) to attempt a GET request to the new `/download-strategy/objects/{key}` endpoint first, falling back to the legacy POST endpoint on 404 or 405 errors.
>
> - The legacy POST no longer sends an `expiresIn: 3600` payload in either the primary or fallback request.
> - Behavioral Change: backends that return errors other than 404/405 will not trigger the fallback and will surface the error directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b3faa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->