### PR TITLE
Add additional parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ await insforge.auth.signInWithOAuth("google", {
   redirectTo: "http://localhost:3000/dashboard",
   additionalParams: { prompt: "select_account" },
 });
+// additionalParams is for provider-specific hints only.
+// Do not pass client_id, scope, redirect_uri, code_challenge, state, or response_type;
+// InsForge sets server-owned OAuth fields and ignores colliding client-provided keys.
 
 // Get current user (call this during browser app startup)
 const { data: currentUser } = await insforge.auth.getCurrentUser();

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ const { data, error } = await insforge.auth.signInWithPassword({
 });
 
 // OAuth authentication (built-in or custom provider key)
-await insforge.auth.signInWithOAuth({
-  provider: "google", // e.g. built-in: "google", custom: "auth0-acme"
+await insforge.auth.signInWithOAuth("google", {
   redirectTo: "http://localhost:3000/dashboard",
+  additionalParams: { prompt: "select_account" },
 });
 
 // Get current user (call this during browser app startup)

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -219,6 +219,9 @@ await insforge.auth.signInWithOAuth("google", {
 });
 // Response: { data: { url, provider }, error }
 // Auto-redirects in browser unless skipBrowserRedirect: true
+// additionalParams is for provider-specific hints only. Do not pass client_id, scope,
+// redirect_uri, code_challenge, state, or response_type; InsForge sets those server-side
+// and ignores colliding client-provided keys.
 
 // AUTOMATIC OAuth Callback Detection (v0.0.14+):
 // When users are redirected back from OAuth provider, the SDK automatically:

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -212,9 +212,9 @@ await insforge.auth.signInWithPassword({
 ### `signInWithOAuth()`
 
 ```javascript
-await insforge.auth.signInWithOAuth({
-  provider: "google", // built-in (e.g. "google") or custom provider key (e.g. "auth0-acme")
+await insforge.auth.signInWithOAuth("google", {
   redirectTo: "http://localhost:3000/dashboard",
+  additionalParams: { prompt: "select_account" }, // optional provider-specific OAuth params
   skipBrowserRedirect: true, // optional, returns URL instead of redirecting
 });
 // Response: { data: { url, provider }, error }

--- a/integration-tests/auth.test.ts
+++ b/integration-tests/auth.test.ts
@@ -421,10 +421,13 @@ describe('Auth Module', () => {
   describe('signInWithOAuth()', () => {
     it('should return an OAuth URL for a built-in provider', async () => {
       const c = createClient();
-      const { data, error } = await c.auth.signInWithOAuth({
-        provider: 'google',
-        skipBrowserRedirect: true,
-      });
+      const { data, error } = await c.auth.signInWithOAuth(
+        'google',
+        {
+          redirectTo: 'http://localhost:3000/dashboard',
+          skipBrowserRedirect: true,
+        },
+      );
 
       // Provider may not be configured – both outcomes are valid
       if (error) {
@@ -437,10 +440,13 @@ describe('Auth Module', () => {
 
     it('should return an OAuth URL for a custom provider', async () => {
       const c = createClient();
-      const { data, error } = await c.auth.signInWithOAuth({
-        provider: 'custom-test-provider',
-        skipBrowserRedirect: true,
-      });
+      const { data, error } = await c.auth.signInWithOAuth(
+        'custom-test-provider',
+        {
+          redirectTo: 'http://localhost:3000/dashboard',
+          skipBrowserRedirect: true,
+        },
+      );
 
       // Custom provider likely not configured – verify structured error
       if (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.55",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@insforge/shared-schemas": "^1.1.53",
+        "@insforge/shared-schemas": "^1.1.55",
         "@supabase/postgrest-js": "^1.21.3",
         "socket.io-client": "^4.8.1"
       },
@@ -690,9 +690,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.53",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.53.tgz",
-      "integrity": "sha512-YdeN+9U8qSH6o8yP0f0l7saBZjlFKVCsOnyrNWAuy+PsM4X7noaNKOm+SHkvshin6K7BXArcnN/b382wLQBLNw==",
+      "version": "1.1.55",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.55.tgz",
+      "integrity": "sha512-xor4lpP1dRiAASuQ99hl7R8pi/FAiCmN7iLLlNT5nEUvDUDbI6Ja4hJt/ElkR1jxliiMlx1u3gMMCkrWAyvJVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "url": "https://github.com/InsForge/insforge-sdk-js/issues"
   },
   "dependencies": {
-    "@insforge/shared-schemas": "^1.1.53",
+    "@insforge/shared-schemas": "^1.1.55",
     "@supabase/postgrest-js": "^1.21.3",
     "socket.io-client": "^4.8.1"
   },

--- a/src/modules/auth/__tests__/auth.test.ts
+++ b/src/modules/auth/__tests__/auth.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HttpClient } from '../../../lib/http-client';
+import { TokenManager } from '../../../lib/token-manager';
+import { Auth } from '../auth';
+
+function createJsonResponse(status: number, body: any): Response {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response;
+
+  return {
+    ...response,
+    clone: () => response,
+  } as Response;
+}
+
+describe('Auth', () => {
+  describe('signInWithOAuth()', () => {
+    it('sends provider-specific additionalParams during OAuth init', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        createJsonResponse(200, {
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        }),
+      );
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      const { data, error } = await auth.signInWithOAuth(
+        'google',
+        {
+          redirectTo: 'http://localhost:3000/dashboard',
+          additionalParams: {
+            prompt: 'select_account',
+            login_hint: 'person@example.com',
+          },
+          skipBrowserRedirect: true,
+        },
+      );
+
+      expect(error).toBeNull();
+      expect(data.url).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+
+      const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(requestUrl.pathname).toBe('/api/auth/oauth/google');
+      expect(requestUrl.searchParams.get('redirect_uri')).toBe(
+        'http://localhost:3000/dashboard',
+      );
+      expect(requestUrl.searchParams.get('code_challenge')).toHaveLength(43);
+      expect(requestUrl.searchParams.get('prompt')).toBe('select_account');
+      expect(requestUrl.searchParams.get('login_hint')).toBe(
+        'person@example.com',
+      );
+    });
+
+    it('supports the deprecated object wrapper signature', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        createJsonResponse(200, {
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        }),
+      );
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      const { error } = await auth.signInWithOAuth({
+        provider: 'google',
+        redirectTo: 'http://localhost:3000/dashboard',
+        additionalParams: { prompt: 'select_account' },
+        skipBrowserRedirect: true,
+      });
+
+      expect(error).toBeNull();
+
+      const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(requestUrl.searchParams.get('redirect_uri')).toBe(
+        'http://localhost:3000/dashboard',
+      );
+      expect(requestUrl.searchParams.get('prompt')).toBe('select_account');
+    });
+
+    it('does not let additionalParams override OAuth init fields', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        createJsonResponse(200, {
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        }),
+      );
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      const { error } = await auth.signInWithOAuth(
+        'google',
+        {
+          redirectTo: 'http://localhost:3000/dashboard',
+          additionalParams: {
+            redirect_uri: 'https://evil.example/callback',
+            code_challenge: 'evil',
+            prompt: 'select_account',
+          },
+          skipBrowserRedirect: true,
+        },
+      );
+
+      expect(error).toBeNull();
+
+      const requestUrl = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(requestUrl.searchParams.get('redirect_uri')).toBe(
+        'http://localhost:3000/dashboard',
+      );
+      expect(requestUrl.searchParams.get('code_challenge')).toHaveLength(43);
+      expect(requestUrl.searchParams.get('code_challenge')).not.toBe('evil');
+      expect(requestUrl.searchParams.get('prompt')).toBe('select_account');
+      expect(requestUrl.searchParams.has('additionalParams[redirect_uri]')).toBe(
+        false,
+      );
+      expect(requestUrl.searchParams.has('additionalParams[code_challenge]')).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/src/modules/auth/__tests__/auth.test.ts
+++ b/src/modules/auth/__tests__/auth.test.ts
@@ -3,6 +3,16 @@ import { HttpClient } from '../../../lib/http-client';
 import { TokenManager } from '../../../lib/token-manager';
 import { Auth } from '../auth';
 
+vi.mock('../helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../helpers')>();
+  return {
+    ...actual,
+    generateCodeVerifier: vi.fn(() => 'a'.repeat(43)),
+    generateCodeChallenge: vi.fn(() => Promise.resolve('b'.repeat(43))),
+    storePkceVerifier: vi.fn(),
+  };
+});
+
 function createJsonResponse(status: number, body: any): Response {
   const response = {
     ok: status >= 200 && status < 300,
@@ -13,10 +23,9 @@ function createJsonResponse(status: number, body: any): Response {
     text: () => Promise.resolve(JSON.stringify(body)),
   } as Response;
 
-  return {
-    ...response,
-    clone: () => response,
-  } as Response;
+  (response as any).clone = () => createJsonResponse(status, body);
+
+  return response;
 }
 
 describe('Auth', () => {
@@ -143,6 +152,53 @@ describe('Auth', () => {
       expect(requestUrl.searchParams.has('additionalParams[code_challenge]')).toBe(
         false,
       );
+    });
+
+    it('returns INVALID_INPUT when called without an options object', async () => {
+      const fetchMock = vi.fn();
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      const { error } = await (auth.signInWithOAuth as any)('google');
+
+      expect(error).not.toBeNull();
+      expect(error?.statusCode).toBe(400);
+      expect(error?.error).toBe('INVALID_INPUT');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns INVALID_INPUT when redirectTo is missing at runtime', async () => {
+      const fetchMock = vi.fn();
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      const { error } = await (auth.signInWithOAuth as any)({
+        provider: 'google',
+        additionalParams: { prompt: 'select_account' },
+        skipBrowserRedirect: true,
+      });
+
+      expect(error).not.toBeNull();
+      expect(error?.message).toBe('Redirect URI is required');
+      expect(error?.statusCode).toBe(400);
+      expect(error?.error).toBe('INVALID_INPUT');
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -275,6 +275,17 @@ export class Auth {
         };
       }
 
+      if (!signInOptions || !signInOptions.redirectTo) {
+        return {
+          data: {},
+          error: new InsForgeError(
+            'Redirect URI is required',
+            400,
+            ERROR_CODES.INVALID_INPUT,
+          ),
+        };
+      }
+
       const { provider } = signInOptions;
       const providerKey = encodeURIComponent(provider.toLowerCase());
 

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -27,6 +27,7 @@ import type {
   CreateSessionResponse,
   GetOauthUrlResponse,
   GetPublicAuthConfigResponse,
+  OAuthInitRequest,
   OAuthProvidersSchema,
   SendVerificationEmailRequest,
   SendResetPasswordEmailRequest,
@@ -45,6 +46,16 @@ import { ERROR_CODES, oAuthProvidersSchema } from '@insforge/shared-schemas';
 interface AuthOptions {
   isServerMode?: boolean;
 }
+
+type OAuthSignInOptions = {
+  redirectTo: string;
+  additionalParams?: Record<string, string>;
+  skipBrowserRedirect?: boolean;
+};
+
+type OAuthSignInLegacyOptions = OAuthSignInOptions & {
+  provider: OAuthProvidersSchema | string;
+};
 
 export class Auth {
   private authCallbackHandled: Promise<void>;
@@ -222,24 +233,61 @@ export class Auth {
   /**
    * Sign in with OAuth provider using PKCE flow
    */
-  async signInWithOAuth(options: {
-    provider: OAuthProvidersSchema | string;
-    redirectTo?: string;
-    skipBrowserRedirect?: boolean;
-  }): Promise<{
+  async signInWithOAuth(
+    provider: OAuthProvidersSchema | string,
+    options: OAuthSignInOptions,
+  ): Promise<{
+    data: { url?: string; provider?: string; codeVerifier?: string };
+    error: InsForgeError | null;
+  }>;
+  /**
+   * @deprecated Use signInWithOAuth(provider, { redirectTo, additionalParams, skipBrowserRedirect }).
+   */
+  async signInWithOAuth(options: OAuthSignInLegacyOptions): Promise<{
+    data: { url?: string; provider?: string; codeVerifier?: string };
+    error: InsForgeError | null;
+  }>;
+  async signInWithOAuth(
+    providerOrOptions:
+      | OAuthProvidersSchema
+      | string
+      | OAuthSignInLegacyOptions,
+    options?: OAuthSignInOptions,
+  ): Promise<{
     data: { url?: string; provider?: string; codeVerifier?: string };
     error: InsForgeError | null;
   }> {
     try {
-      const { provider, redirectTo, skipBrowserRedirect } = options;
+      let signInOptions: OAuthSignInLegacyOptions;
+
+      if (typeof providerOrOptions === 'object') {
+        signInOptions = providerOrOptions;
+      } else if (options) {
+        signInOptions = { provider: providerOrOptions, ...options };
+      } else {
+        return {
+          data: {},
+          error: new InsForgeError(
+            'OAuth sign-in options are required',
+            400,
+            ERROR_CODES.INVALID_INPUT,
+          ),
+        };
+      }
+
+      const { provider } = signInOptions;
       const providerKey = encodeURIComponent(provider.toLowerCase());
 
       const codeVerifier = generateCodeVerifier();
       const codeChallenge = await generateCodeChallenge(codeVerifier);
       storePkceVerifier(codeVerifier);
 
-      const params: Record<string, string> = { code_challenge: codeChallenge };
-      if (redirectTo) params.redirect_uri = redirectTo;
+      const params: OAuthInitRequest = {
+        ...(signInOptions.additionalParams ?? {}),
+        redirect_uri: signInOptions.redirectTo,
+        code_challenge: codeChallenge,
+      };
+
       const isBuiltInProvider = oAuthProvidersSchema.options.includes(
         providerKey as OAuthProvidersSchema,
       );
@@ -255,7 +303,7 @@ export class Auth {
       if (
         !this.isServerMode() &&
         typeof window !== 'undefined' &&
-        !skipBrowserRedirect
+        !signInOptions.skipBrowserRedirect
       ) {
         window.location.href = response.authUrl;
         return { data: {}, error: null };


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `additionalParams` support and provider-first signature to `Auth.signInWithOAuth`
> - Adds function overloading to `signInWithOAuth` in [auth.ts](https://github.com/InsForge/InsForge-sdk-js/pull/88/files#diff-b7f37dce2f7643f69ad65823f77dc7fe8162410502cc185cd2d7bf5e3931a9cc): new preferred signature takes `provider` as the first argument and an options object `{ redirectTo, additionalParams, skipBrowserRedirect }` as the second; the old object-wrapper signature is retained as deprecated.
> - Adds `additionalParams` to forward provider-specific OAuth hints in the init request; server-owned fields (`redirect_uri`, `code_challenge`) always override any colliding keys in `additionalParams`.
> - Adds runtime validation returning a 400 `INVALID_INPUT` error when options or `redirectTo` are missing.
> - Behavioral Change: `redirectTo` is now required for both signatures at runtime; callers omitting it will receive an error instead of proceeding silently.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #88 opened
>
> - Incremented version in `package.json` from 1.3.0 to 1.3.1 [4587eb8]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 595788a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `additionalParams` option to support provider-specific OAuth configuration hints during sign-in requests, with built-in protection against overriding server-managed fields.

* **Documentation**
  * Updated OAuth sign-in examples and SDK reference documentation with clarified method signatures and enhanced guidance on OAuth field management.

* **Chores**
  * Package version bumped to 1.3.1 with dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-first `auth.signInWithOAuth(provider, options)` with `additionalParams` for provider-specific OAuth hints. Enforces `redirectTo`, tightens runtime validation, and bumps `@insforge/sdk` to `1.3.1`.

- **New Features**
  - Merges `additionalParams` into the OAuth init request; blocks overrides to `redirect_uri` and `code_challenge`.
  - Returns a 400 `INVALID_INPUT` error when options are missing or `redirectTo` is not provided.
  - Bundles `@insforge/shared-schemas` for CJS and updates to `^1.1.55`.

- **Migration**
  - Replace `signInWithOAuth({ provider, ... })` with `signInWithOAuth("google", { redirectTo, ... })` (`redirectTo` is required).
  - Send provider-specific values via `additionalParams`; the legacy signature still works but is deprecated.

<sup>Written for commit 4587eb89123e902aab6bba07e75aa1c7bc0f50aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

