### PR TITLE
docs: align AI examples with the actual SDK API and return shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,18 +245,39 @@ if (portal?.customerPortalSession.url) {
 
 ### AI Integration
 
-```javascript
-// Generate text completion
-const { data, error } = await insforge.ai.completion({
-  model: "gpt-3.5-turbo",
-  prompt: "Write a hello world program",
-});
+AI methods return an OpenAI-like response object directly (not the `{ data, error }` envelope used by the other modules) and throw on failure.
 
-// Analyze an image
-const { data, error } = await insforge.ai.vision({
-  imageUrl: "https://example.com/image.jpg",
-  prompt: "Describe this image",
+```javascript
+// Chat completion
+const completion = await insforge.ai.chat.completions.create({
+  model: "anthropic/claude-3.5-haiku",
+  messages: [{ role: "user", content: "Write a hello world program" }],
 });
+console.log(completion.choices[0].message.content);
+
+// Streaming chat — returns an async iterable of chunks
+const stream = await insforge.ai.chat.completions.create({
+  model: "anthropic/claude-3.5-haiku",
+  messages: [{ role: "user", content: "Tell me a story" }],
+  stream: true,
+});
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? "");
+}
+
+// Generate an image — returns base64-encoded image data
+const image = await insforge.ai.images.generate({
+  model: "google/gemini-3-pro-image-preview",
+  prompt: "A sunset over mountains",
+});
+const base64Png = image.data[0].b64_json;
+
+// Create embeddings
+const embeddings = await insforge.ai.embeddings.create({
+  model: "openai/text-embedding-3-small",
+  input: "Hello world",
+});
+console.log(embeddings.data[0].embedding); // number[]
 ```
 
 ## Documentation

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -689,7 +689,7 @@ Create AI chat completions with support for both streaming and non-streaming res
 #### Non-Streaming
 
 ```javascript
-const { data, error } = await insforge.ai.chat.completions.create({
+const completion = await insforge.ai.chat.completions.create({
   model: "anthropic/claude-3.5-haiku",
   messages: [
     { role: "system", content: "You are a helpful assistant" },
@@ -698,32 +698,27 @@ const { data, error } = await insforge.ai.chat.completions.create({
   temperature: 0.7,
   maxTokens: 500,
 });
-// Response: { data: { response, usage, model }, error }
-// response: The complete AI response text
-// usage: Token usage information
-// model: The model used for generation
+// Returns an OpenAI-like completion object directly (not a { data, error } envelope):
+// completion.choices[0].message.content - the complete AI response text
+// completion.usage                      - token usage information
+// completion.model                      - the model used for generation
+console.log(completion.choices[0].message.content);
 ```
 
 #### Streaming
 
 ```javascript
-// Returns async iterable for real-time streaming
+// Returns an async iterable of OpenAI-like chunks for real-time streaming
 const stream = await insforge.ai.chat.completions.create({
   model: "anthropic/claude-3.5-haiku",
   messages: [{ role: "user", content: "Tell me a story" }],
   stream: true,
 });
 
-// Process stream events
-for await (const event of stream) {
-  if (event.chunk) {
-    // Partial response chunk
-    process.stdout.write(event.chunk);
-  }
-  if (event.done) {
-    // Stream complete
-    console.log("\nStream finished");
-  }
+// Each chunk carries an incremental delta in choices[0].delta.content
+for await (const chunk of stream) {
+  const delta = chunk.choices[0]?.delta?.content;
+  if (delta) process.stdout.write(delta);
 }
 ```
 
@@ -731,42 +726,67 @@ for await (const event of stream) {
 
 - `model` (string, required): AI model to use (e.g., 'anthropic/claude-3.5-haiku', 'openai/gpt-4', etc.)
 - `messages` (array): Conversation messages with role ('system', 'user', 'assistant') and content
-- `message` (string): Simple message string (alternative to messages array)
-- `systemPrompt` (string): System prompt for the conversation
-- `temperature` (number): Sampling temperature (0-1)
+- `temperature` (number): Sampling temperature (0-2)
 - `maxTokens` (number): Maximum tokens to generate
-- `topP` (number): Top-p sampling parameter
+- `topP` (number): Top-p sampling parameter (0-1)
 - `stream` (boolean): Enable streaming mode
+- `thinking` (boolean): Enable chain-of-thought reasoning (supported models)
+- `webSearch`, `fileParser`, `tools`, `toolChoice`, `parallelToolCalls`: Optional plugin/tool-calling options — see the SDK source for their shapes
 
 ### `ai.images.generate()`
 
 Generate images using AI models.
 
 ```javascript
-const { data, error } = await insforge.ai.images.generate({
-  model: "google/gemini-2.5-flash-image-preview",
+// Text-to-image
+const image = await insforge.ai.images.generate({
+  model: "google/gemini-3-pro-image-preview",
   prompt: "A serene landscape with mountains at sunset",
-  size: "1024x1024",
-  numImages: 1,
-  quality: "hd",
-  style: "vivid",
 });
-// Response: { data: { images: [{ url, ... }] }, error }
-// images: Array of generated images with URLs
+// Returns an OpenAI-like image object directly (not a { data, error } envelope):
+// image.data[i].b64_json - base64-encoded image (no `data:` URI prefix)
+// image.data[i].content  - text output, for text-capable image models
+// image.usage            - token usage (when reported by the model)
+const base64Png = image.data[0].b64_json;
+
+// Image-to-image — pass source images as URLs or base64 data URIs
+const edited = await insforge.ai.images.generate({
+  model: "google/gemini-3-pro-image-preview",
+  prompt: "Turn this into a watercolor painting",
+  images: [{ url: "https://example.com/input.jpg" }],
+});
 ```
 
 #### Parameters
 
-- `model` (string, required): Image generation model (e.g., 'google/gemini-2.5-flash-image-preview', 'openai/dall-e-3', 'stable-diffusion', etc.)
+- `model` (string, required): Image generation model (e.g., 'google/gemini-3-pro-image-preview', 'openai/dall-e-3')
 - `prompt` (string, required): Text description of the image to generate
-- `negativePrompt` (string): What to avoid in the image (some models)
-- `width` (number): Image width in pixels
-- `height` (number): Image height in pixels
-- `size` (string): Predefined size (e.g., '1024x1024', '512x512')
-- `numImages` (number): Number of images to generate
-- `quality` ('standard' | 'hd'): Image quality setting
-- `style` ('vivid' | 'natural'): Image style preference
-- `responseFormat` ('url' | 'b64_json'): Response format for images
+- `images` (array): Optional source images for image-to-image, each `{ url: string }` (HTTPS URL or `data:` base64 URI)
+
+> The SDK normalizes generated images to base64 and exposes them as `image.data[i].b64_json`.
+
+### `ai.embeddings.create()`
+
+Create embeddings for one or more text inputs.
+
+```javascript
+const embeddings = await insforge.ai.embeddings.create({
+  model: "openai/text-embedding-3-small",
+  input: "Hello world", // or string[] for batch input
+});
+// Returns an OpenAI-like embeddings object directly (not a { data, error } envelope):
+// embeddings.data[i].embedding - the vector (number[]) for input i
+// embeddings.usage             - token usage information
+// embeddings.model             - the model used
+console.log(embeddings.data[0].embedding);
+```
+
+#### Parameters
+
+- `model` (string, required): Embedding model (e.g., 'openai/text-embedding-3-small')
+- `input` (string | string[], required): Text(s) to embed
+- `dimensions` (number): Output dimensions, if supported by the model
+- `encoding_format` ('float' | 'base64'): Encoding of the returned vectors
 
 ### Complete AI Example
 
@@ -778,11 +798,11 @@ const insforge = createClient({
 });
 
 // Chat completion
-const { data: chat } = await insforge.ai.chat.completions.create({
+const chat = await insforge.ai.chat.completions.create({
   model: "anthropic/claude-3.5-haiku",
   messages: [{ role: "user", content: "What is the capital of France?" }],
 });
-console.log(chat.response); // "The capital of France is Paris."
+console.log(chat.choices[0].message.content); // "The capital of France is Paris."
 
 // Streaming chat
 const stream = await insforge.ai.chat.completions.create({
@@ -792,21 +812,27 @@ const stream = await insforge.ai.chat.completions.create({
 });
 
 let fullResponse = "";
-for await (const event of stream) {
-  if (event.chunk) {
-    fullResponse += event.chunk;
-    process.stdout.write(event.chunk);
+for await (const chunk of stream) {
+  const delta = chunk.choices[0]?.delta?.content;
+  if (delta) {
+    fullResponse += delta;
+    process.stdout.write(delta);
   }
 }
 
 // Image generation
-const { data: images } = await insforge.ai.images.generate({
-  model: "google/gemini-2.5-flash-image-preview",
+const image = await insforge.ai.images.generate({
+  model: "google/gemini-3-pro-image-preview",
   prompt: "A futuristic city with flying cars",
-  size: "1024x1024",
-  quality: "hd",
 });
-console.log(images.images[0].url); // URL to generated image
+const base64Png = image.data[0].b64_json; // base64-encoded image
+
+// Embeddings
+const embeddings = await insforge.ai.embeddings.create({
+  model: "openai/text-embedding-3-small",
+  input: "Vectorize this sentence",
+});
+console.log(embeddings.data[0].embedding); // number[]
 ```
 
 ## Types (from @insforge/shared-schemas)

--- a/src/modules/ai.ts
+++ b/src/modules/ai.ts
@@ -343,7 +343,7 @@ class Images {
    *   model: 'dall-e-3',
    *   prompt: 'A sunset over mountains',
    * });
-   * console.log(response.images[0].url);
+   * console.log(response.data[0].b64_json);
    *
    * // Image-to-image (with input images)
    * const response = await client.ai.images.generate({


### PR DESCRIPTION
## What

Aligns the AI examples in `README.md` and `SDK-REFERENCE.md` (and one `ai.ts` JSDoc example) with the AI module's actual API and return shapes.

## Why

The docs referenced methods that don't exist (`ai.completion`, `ai.vision`) and destructured responses incorrectly (`{ data, error }`, `chat.response`, `images.images[0].url`).

Copy-pasting these examples fails at runtime or teaches the wrong return shape.

## How

- **README**
  - Replaced the `ai.completion` / `ai.vision` examples with:
    - `ai.chat.completions.create`
    - `ai.images.generate`
    - `ai.embeddings.create`
  - Added a note that AI methods return OpenAI-style response objects directly and throw on failure.

- **SDK-REFERENCE**
  - Corrected chat, streaming, image, and embeddings examples to use the actual response shapes.
  - Updated parameter lists to match `@insforge/shared-schemas` request schemas.
  - Removed fictional image parameters.
  - Removed nonexistent chat parameters (`message`, `systemPrompt`).
  - Added an embeddings section.

- **ai.ts**
  - Fixed the `images.generate` JSDoc example to use `data[0].b64_json`.
  - Removed the incorrect `images[0].url` reference.

## How to Test

```bash
npm run typecheck
npm test
```

Expected results:

- `npm run typecheck`  -- passes
- `npm test` -- 131/131 tests pass
- Cross-checked against:
  - `@insforge/shared-schemas@1.1.53`
  - `integration-tests/ai.test.ts`

## Related

Closes #76


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns AI examples in README and SDK reference to the actual SDK API and return shapes so copy‑paste works and matches OpenAI‑like responses. Also fixes the `images.generate` JSDoc example and updates params to match `@insforge/shared-schemas`. Closes #76.

- **Bug Fixes**
  - Replaced `ai.completion`/`ai.vision` with `ai.chat.completions.create`, `ai.images.generate`, `ai.embeddings.create`.
  - Corrected return handling: `choices[0].message.content`, streaming `choices[0].delta.content`, images `data[0].b64_json`, embeddings `data[0].embedding`; methods throw on failure.
  - Synced parameter lists with `@insforge/shared-schemas` (removed nonexistent chat/image params; added embeddings and documented supported options).
  - Fixed `ai.ts` JSDoc to use `response.data[0].b64_json`.

<sup>Written for commit 06854dead2be5bc1fd1a68682d854cd3af22e4dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align AI SDK docs and JSDoc examples with OpenAI-like return shapes
> - Updates [README.md](https://github.com/InsForge/InsForge-sdk-js/pull/89/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [SDK-REFERENCE.md](https://github.com/InsForge/InsForge-sdk-js/pull/89/files#diff-1cbded2952b2494dc57da250e6b891b270b3a605491617b4f0cbf81f0efc93f5) to remove the `{ data, error }` envelope pattern and replace it with direct return values that throw on failure, matching the actual SDK API.
> - Rewrites chat completion examples to use `insforge.ai.chat.completions.create` and read from `choices[0].message.content` (non-streaming) and `choices[0]?.delta?.content` (streaming).
> - Updates image generation examples to read base64 from `image.data[0].b64_json` and adds an image-to-image example; adds a new embeddings section using `ai.embeddings.create` returning vectors via `embeddings.data[i].embedding`.
> - Fixes the `Images.generate` JSDoc in [src/modules/ai.ts](https://github.com/InsForge/InsForge-sdk-js/pull/89/files#diff-fbf3c67ffac620e12d07ee0d35d85327700f0d96162e30e3147893519b420fe2) to reference `response.data[0].b64_json` instead of `response.images[0].url`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06854de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation and examples to reflect new OpenAI-compatible response object formats for AI features.
  * Refreshed examples for chat completions, streaming, image generation, and embeddings with current response structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->