### PR TITLE
feat(storage): signed URLs + Supabase-shaped getPublicUrl

### DIFF
--- a/integration-tests/storage.test.ts
+++ b/integration-tests/storage.test.ts
@@ -69,22 +69,23 @@ describe('Storage Module', () => {
 
   describe('getPublicUrl()', () => {
     it('should build a correct public URL', () => {
-      const url = client.storage.from(BUCKET).getPublicUrl('images/logo.png');
-      expect(url).toContain(env.baseUrl);
-      expect(url).toContain(BUCKET);
-      expect(url).toContain('images%2Flogo.png');
+      const { data, error } = client.storage.from(BUCKET).getPublicUrl('images/logo.png');
+      expect(error).toBeNull();
+      expect(data?.publicUrl).toContain(env.baseUrl);
+      expect(data?.publicUrl).toContain(BUCKET);
+      expect(data?.publicUrl).toContain('images%2Flogo.png');
     });
 
     it('should handle nested paths', () => {
-      const url = client.storage.from(BUCKET).getPublicUrl('a/b/c/file.txt');
-      expect(url).toContain('a%2Fb%2Fc%2Ffile.txt');
+      const { data } = client.storage.from(BUCKET).getPublicUrl('a/b/c/file.txt');
+      expect(data?.publicUrl).toContain('a%2Fb%2Fc%2Ffile.txt');
     });
 
     it('should handle paths with special characters', () => {
-      const url = client.storage.from(BUCKET).getPublicUrl('files/my doc (1).pdf');
-      expect(url).toContain(BUCKET);
+      const { data } = client.storage.from(BUCKET).getPublicUrl('files/my doc (1).pdf');
+      expect(data?.publicUrl).toContain(BUCKET);
       // URL encoding should be applied
-      expect(url).toBeDefined();
+      expect(data?.publicUrl).toBeDefined();
     });
   });
 

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StorageBucket } from '../storage';
+import { HttpClient } from '../../lib/http-client';
+import { InsForgeError } from '../../types';
+import { TokenManager } from '../../lib/token-manager';
+
+function makeTokenManager(): TokenManager {
+  return {
+    saveSession: vi.fn(),
+    clearSession: vi.fn(),
+    getSession: vi.fn().mockReturnValue(null),
+    getAccessToken: vi.fn().mockReturnValue(null),
+  } as unknown as TokenManager;
+}
+
+function makeHttp(fetchFn: ReturnType<typeof vi.fn>) {
+  return new HttpClient(
+    {
+      baseUrl: 'http://localhost:7130',
+      fetch: fetchFn as any,
+      retryCount: 0,
+      timeout: 0,
+    },
+    makeTokenManager(),
+  );
+}
+
+function jsonRes(status: number, body: any, statusText = 'OK'): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('StorageBucket.getPublicUrl', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns { data: { publicUrl }, error } and makes no request', () => {
+    const fetchFn = vi.fn();
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = bucket.getPublicUrl('images/logo.png');
+
+    expect(result).toEqual({
+      data: {
+        publicUrl: 'http://localhost:7130/api/storage/buckets/docs/objects/images%2Flogo.png',
+      },
+      error: null,
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('encodes special characters and nested paths', () => {
+    const bucket = new StorageBucket('docs', makeHttp(vi.fn()));
+
+    const { data } = bucket.getPublicUrl('files/my doc (1).pdf');
+
+    expect(data?.publicUrl).toContain('docs');
+    expect(data?.publicUrl).toContain('files%2Fmy%20doc%20(1).pdf');
+  });
+});
+
+describe('StorageBucket.createSignedUrl', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs the download-strategy endpoint with expiresIn and returns the signed URL', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonRes(200, {
+        method: 'presigned',
+        url: 'https://cdn.insforge.dev/storage/app/docs/invoice.pdf?Signature=abc',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.createSignedUrl('invoice.pdf', 120);
+
+    expect(result.error).toBeNull();
+    expect(result.data?.signedUrl).toBe(
+      'https://cdn.insforge.dev/storage/app/docs/invoice.pdf?Signature=abc',
+    );
+    expect(result.data?.expiresAt).toBe('2026-01-01T00:00:00.000Z');
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const url = new URL(String(fetchFn.mock.calls[0][0]));
+    expect(url.pathname).toBe('/api/storage/buckets/docs/download-strategy/objects/invoice.pdf');
+    expect(url.searchParams.get('expiresIn')).toBe('120');
+  });
+
+  it('defaults expiresIn to 3600 and returns expiresAt: null when absent', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonRes(200, { method: 'presigned', url: 'https://cdn.insforge.dev/x' }),
+    );
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.createSignedUrl('x.pdf');
+
+    expect(result.data?.signedUrl).toBe('https://cdn.insforge.dev/x');
+    expect(result.data?.expiresAt).toBeNull();
+    const url = new URL(String(fetchFn.mock.calls[0][0]));
+    expect(url.searchParams.get('expiresIn')).toBe('3600');
+  });
+
+  it('maps a non-2xx response to { data: null, error: InsForgeError }', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonRes(404, { error: 'STORAGE_NOT_FOUND', message: 'Object not found' }, 'Not Found'),
+    );
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.createSignedUrl('missing.pdf');
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBeInstanceOf(InsForgeError);
+    expect(result.error?.statusCode).toBe(404);
+  });
+});
+
+describe('StorageBucket.createSignedUrls', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves each path independently; one failure does not fail the rest', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(200, { method: 'presigned', url: 'https://cdn/ok1' }))
+      .mockResolvedValueOnce(
+        jsonRes(404, { error: 'STORAGE_NOT_FOUND', message: 'nope' }, 'Not Found'),
+      )
+      .mockResolvedValueOnce(jsonRes(200, { method: 'presigned', url: 'https://cdn/ok3' }));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.createSignedUrls(['a.pdf', 'missing.pdf', 'c.pdf'], 60);
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([
+      { path: 'a.pdf', signedUrl: 'https://cdn/ok1', error: null },
+      { path: 'missing.pdf', signedUrl: null, error: 'nope' },
+      { path: 'c.pdf', signedUrl: 'https://cdn/ok3', error: null },
+    ]);
+
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(new URL(String(fetchFn.mock.calls[0][0])).searchParams.get('expiresIn')).toBe('60');
+  });
+});

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -117,6 +117,30 @@ describe('StorageBucket.createSignedUrl', () => {
     expect(result.data).toBeNull();
     expect(result.error).toBeInstanceOf(InsForgeError);
     expect(result.error?.statusCode).toBe(404);
+    // STORAGE_NOT_FOUND is a real miss, not a missing route — no POST fallback.
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to the legacy POST route when the GET route 404s on older backends', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(404, { error: 'NOT_FOUND', message: 'no route' }, 'Not Found'))
+      .mockResolvedValueOnce(jsonRes(200, { method: 'presigned', url: 'https://cdn/ok' }));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.createSignedUrl('invoice.pdf', 120);
+
+    expect(result.error).toBeNull();
+    expect(result.data?.signedUrl).toBe('https://cdn/ok');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    // First the canonical GET, then the legacy POST alias.
+    expect(new URL(String(fetchFn.mock.calls[0][0])).pathname).toBe(
+      '/api/storage/buckets/docs/download-strategy/objects/invoice.pdf',
+    );
+    expect(new URL(String(fetchFn.mock.calls[1][0])).pathname).toBe(
+      '/api/storage/buckets/docs/objects/invoice.pdf/download-strategy',
+    );
+    expect(String(fetchFn.mock.calls[1][1]?.method)).toBe('POST');
   });
 });
 

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -219,7 +219,7 @@ export class StorageBucket {
           size: file.size,
           mimeType: file.type || 'application/octet-stream',
           uploadedAt: new Date().toISOString(),
-          url: this.getPublicUrl(strategy.key)
+          url: this.getPublicUrl(strategy.key).data!.publicUrl
         } as StorageFileSchema,
         error: null
       };
@@ -308,11 +308,98 @@ export class StorageBucket {
   }
 
   /**
-   * Get public URL for a file
+   * Get the public URL for an object in a public bucket.
+   *
+   * Pure string construction — no network call, no auth. The URL only resolves
+   * if the bucket is public; for private objects use {@link createSignedUrl}.
+   *
    * @param path - The object key/path
+   * @returns `{ data: { publicUrl }, error }` — matches the external SDK pattern,
+   *   so `const { data } = getPublicUrl(path)` then `data.publicUrl`.
    */
-  getPublicUrl(path: string): string {
-    return `${this.http.baseUrl}/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}`;
+  getPublicUrl(path: string): StorageResponse<{ publicUrl: string }> {
+    const publicUrl = `${this.http.baseUrl}/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}`;
+    return { data: { publicUrl }, error: null };
+  }
+
+  /**
+   * Create a signed URL for an object.
+   *
+   * Returns a time-limited, credential-free URL that can be handed directly to
+   * a browser (`<img src>`), an email, or a third party — no SDK or session is
+   * needed to fetch it. Authorization is enforced when the URL is minted (the
+   * caller must be allowed to read the object), so the resulting link is a
+   * pre-authorized capability scoped to this one object until it expires.
+   *
+   * @param path - The object key/path
+   * @param expiresIn - Lifetime in seconds (default 3600 = 1h, max 604800 = 7d).
+   *   Honored for private buckets; public buckets return their long-lived URL.
+   */
+  async createSignedUrl(
+    path: string,
+    expiresIn = 3600
+  ): Promise<StorageResponse<{ signedUrl: string; expiresAt: string | null }>> {
+    try {
+      const strategy = await this.http.get<DownloadStrategy>(
+        `/api/storage/buckets/${this.bucketName}/download-strategy/objects/${encodeURIComponent(path)}`,
+        { params: { expiresIn: expiresIn.toString() } }
+      );
+
+      return {
+        data: {
+          signedUrl: strategy.url,
+          expiresAt: strategy.expiresAt ? new Date(strategy.expiresAt).toISOString() : null,
+        },
+        error: null,
+      };
+    } catch (error) {
+      return {
+        data: null,
+        error:
+          error instanceof InsForgeError
+            ? error
+            : new InsForgeError('Failed to create signed URL', 500, 'STORAGE_ERROR'),
+      };
+    }
+  }
+
+  /**
+   * Create signed URLs for multiple objects in a single call.
+   *
+   * Each entry resolves independently: a failure on one key (not found / not
+   * permitted) is reported on that entry's `error` without failing the rest.
+   *
+   * @param paths - The object keys/paths
+   * @param expiresIn - Lifetime in seconds (default 3600 = 1h, max 604800 = 7d)
+   */
+  async createSignedUrls(
+    paths: string[],
+    expiresIn = 3600
+  ): Promise<
+    StorageResponse<Array<{ path: string; signedUrl: string | null; error: string | null }>>
+  > {
+    try {
+      const data = await Promise.all(
+        paths.map(async (path) => {
+          const { data: signed, error } = await this.createSignedUrl(path, expiresIn);
+          return {
+            path,
+            signedUrl: signed?.signedUrl ?? null,
+            error: error ? error.message : null,
+          };
+        })
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return {
+        data: null,
+        error:
+          error instanceof InsForgeError
+            ? error
+            : new InsForgeError('Failed to create signed URLs', 500, 'STORAGE_ERROR'),
+      };
+    }
   }
 
   /**

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -323,6 +323,37 @@ export class StorageBucket {
   }
 
   /**
+   * Resolve a download strategy (signed or direct URL) for an object with a
+   * caller-supplied TTL. Prefers the canonical GET route and falls back to the
+   * legacy POST alias so signed-URL creation still works against older backends
+   * that predate the GET route (they return 404/405 for it). A genuine
+   * "object not found" (STORAGE_NOT_FOUND) is not retried.
+   */
+  private async requestDownloadStrategy(
+    path: string,
+    expiresIn: number
+  ): Promise<DownloadStrategy> {
+    const encoded = encodeURIComponent(path);
+    try {
+      return await this.http.get<DownloadStrategy>(
+        `/api/storage/buckets/${this.bucketName}/download-strategy/objects/${encoded}`,
+        { params: { expiresIn: expiresIn.toString() } }
+      );
+    } catch (error) {
+      const status = error instanceof InsForgeError ? error.statusCode : undefined;
+      const isMissingRoute =
+        (status === 404 || status === 405) &&
+        !(error instanceof InsForgeError && error.error === 'STORAGE_NOT_FOUND');
+      if (!isMissingRoute) throw error;
+
+      return await this.http.post<DownloadStrategy>(
+        `/api/storage/buckets/${this.bucketName}/objects/${encoded}/download-strategy`,
+        { expiresIn }
+      );
+    }
+  }
+
+  /**
    * Create a signed URL for an object.
    *
    * Returns a time-limited, credential-free URL that can be handed directly to
@@ -340,10 +371,7 @@ export class StorageBucket {
     expiresIn = 3600
   ): Promise<StorageResponse<{ signedUrl: string; expiresAt: string | null }>> {
     try {
-      const strategy = await this.http.get<DownloadStrategy>(
-        `/api/storage/buckets/${this.bucketName}/download-strategy/objects/${encodeURIComponent(path)}`,
-        { params: { expiresIn: expiresIn.toString() } }
-      );
+      const strategy = await this.requestDownloadStrategy(path, expiresIn);
 
       return {
         data: {


### PR DESCRIPTION
## What

Adds Supabase-compatible signed-URL helpers to the storage module and aligns `getPublicUrl` to the external SDK pattern.

- `createSignedUrl(path, expiresIn = 3600)` → `{ data: { signedUrl, expiresAt }, error }` — wraps the existing `download-strategy` endpoint and returns the time-limited, credential-free URL string (RLS enforced at mint server-side).
- `createSignedUrls(paths, expiresIn = 3600)` → `{ data: [{ path, signedUrl, error }], error }` — each path resolves independently.
- `getPublicUrl(path)` now returns `{ data: { publicUrl }, error }` instead of a raw `string`, matching Supabase and the rest of the SDK's `{ data, error }` convention.

Pairs with InsForge/InsForge#1496 (backend: honor caller-supplied `expiresIn`).

## ⚠️ Breaking change
`getPublicUrl` return type changed `string` → `{ data: { publicUrl }, error }`. Callers must read `.data.publicUrl`. Warrants a major version bump at publish time.

## Out of scope (Supabase parity gaps)
- Image `transform` options — intentionally excluded.
- `options: { download }` — needs backend `Content-Disposition` support (S3 `ResponseContentDisposition` / CloudFront); fast-follow.

## Tests
- New unit tests `src/modules/__tests__/storage.test.ts` (6) — getPublicUrl shape/encoding, createSignedUrl forwarding/defaults/errors, createSignedUrls independence. All pass.
- Updated the getPublicUrl integration test to the new shape.
- typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized public URL responses and added single and batch signed URL generation with optional expiration and per-item success/error reporting.

* **Bug Fixes**
  * Improved URL encoding for paths (including nested and special-character paths) and added fallback for legacy download strategy when needed.

* **Tests**
  * Expanded integration and unit tests covering public URL formats, signed URL creation, batch behavior, error mapping, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add signed URL creation and reshape `getPublicUrl` to return a structured response in `StorageBucket`
> - `getPublicUrl` now returns `{ data: { publicUrl }, error }` instead of a plain string, matching Supabase's API shape.
> - Adds `createSignedUrl` with a default TTL of 3600s, returning `{ data: { signedUrl, expiresAt }, error }`. Uses a GET endpoint first and falls back to a legacy POST route on 404.
> - Adds `createSignedUrls` for batch signed URL creation; each path resolves independently so a single failure does not affect others.
> - Risk: `getPublicUrl` is a breaking change — callers previously receiving a string must now destructure `data.publicUrl`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f68aaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->