### PR TITLE
Add provider-scoped Razorpay payments SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,13 +206,16 @@ const { data, error } = await insforge.functions.invoke("my-function", {
 
 ```javascript
 // Create and redirect to a Stripe Checkout Session
-const { data, error } = await insforge.payments.createCheckoutSession("test", {
-  mode: "payment",
-  lineItems: [{ stripePriceId: "price_123", quantity: 1 }],
-  successUrl: `${window.location.origin}/success`,
-  cancelUrl: `${window.location.origin}/pricing`,
-  idempotencyKey: "cart_123",
-});
+const { data, error } = await insforge.payments.stripe.createCheckoutSession(
+  "test",
+  {
+    mode: "payment",
+    lineItems: [{ priceId: "price_123", quantity: 1 }],
+    successUrl: `${window.location.origin}/success`,
+    cancelUrl: `${window.location.origin}/pricing`,
+    idempotencyKey: "cart_123",
+  },
+);
 
 if (!error && data?.checkoutSession.url) {
   window.location.assign(data.checkoutSession.url);
@@ -220,10 +223,10 @@ if (!error && data?.checkoutSession.url) {
 
 // Create a subscription checkout for an app billing subject
 const { data: subscriptionCheckout } =
-  await insforge.payments.createCheckoutSession("test", {
+  await insforge.payments.stripe.createCheckoutSession("test", {
     mode: "subscription",
     subject: { type: "team", id: "team_123" },
-    lineItems: [{ stripePriceId: "price_monthly_123", quantity: 1 }],
+    lineItems: [{ priceId: "price_monthly_123", quantity: 1 }],
     successUrl: `${window.location.origin}/billing/success`,
     cancelUrl: `${window.location.origin}/billing`,
   });
@@ -233,17 +236,45 @@ if (subscriptionCheckout?.checkoutSession.url) {
 }
 
 // Let an authenticated customer manage their subscription in Stripe Billing Portal
-const { data: portal } = await insforge.payments.createCustomerPortalSession(
-  "test",
-  {
+const { data: portal } =
+  await insforge.payments.stripe.createCustomerPortalSession("test", {
     subject: { type: "team", id: "team_123" },
     returnUrl: `${window.location.origin}/billing`,
-  },
-);
+  });
 
 if (portal?.customerPortalSession.url) {
   window.location.assign(portal.customerPortalSession.url);
 }
+
+// Create a Razorpay order, then pass checkoutOptions to Razorpay Checkout.js
+const { data: order } = await insforge.payments.razorpay.createOrder("test", {
+  amount: 200000,
+  currency: "INR",
+  subject: { type: "team", id: "team_123" },
+  customerEmail: "ada@example.com",
+});
+
+if (order) {
+  const checkout = new Razorpay({
+    ...order.checkoutOptions,
+    handler: async (response) => {
+      await insforge.payments.razorpay.verifyOrder("test", {
+        orderId: response.razorpay_order_id,
+        paymentId: response.razorpay_payment_id,
+        signature: response.razorpay_signature,
+      });
+    },
+  });
+  checkout.open();
+}
+
+// Create a Razorpay subscription checkout for an app billing subject
+const { data: subscription } =
+  await insforge.payments.razorpay.createSubscription("test", {
+    planId: "plan_123",
+    totalCount: 12,
+    subject: { type: "team", id: "team_123" },
+  });
 ```
 
 ### AI Integration

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ const { data: order } = await insforge.payments.razorpay.createOrder("test", {
   currency: "INR",
   subject: { type: "team", id: "team_123" },
   customerEmail: "ada@example.com",
+  notes: { order_id: "order_123" },
 });
 
 if (order) {
@@ -274,6 +275,7 @@ const { data: subscription } =
     planId: "plan_123",
     totalCount: 12,
     subject: { type: "team", id: "team_123" },
+    notes: { order_id: "order_123" },
   });
 ```
 

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -382,18 +382,21 @@ await insforge.auth.resetPassword({
 
 ## Payments Methods
 
-Payments methods are intended for generated app frontends. They call runtime-safe backend routes using the current user token or anon key. Admin-only Stripe key, product, price, sync, and webhook configuration APIs are intentionally not exposed through this frontend SDK surface.
+Payments methods are provider-scoped and intended for generated app frontends. They call runtime-safe backend routes using the current user token or anon key. Admin-only key, catalog, sync, transaction, and webhook configuration APIs are intentionally not exposed through this frontend SDK surface.
 
-### `createCheckoutSession()`
+### `stripe.createCheckoutSession()`
 
 ```javascript
-const { data, error } = await insforge.payments.createCheckoutSession("test", {
-  mode: "payment",
-  lineItems: [{ stripePriceId: "price_123", quantity: 1 }],
-  successUrl: "https://example.com/success",
-  cancelUrl: "https://example.com/pricing",
-  idempotencyKey: "cart_123", // optional, recommended for retry-safe checkout creation
-});
+const { data, error } = await insforge.payments.stripe.createCheckoutSession(
+  "test",
+  {
+    mode: "payment",
+    lineItems: [{ priceId: "price_123", quantity: 1 }],
+    successUrl: "https://example.com/success",
+    cancelUrl: "https://example.com/pricing",
+    idempotencyKey: "cart_123", // optional, recommended for retry-safe checkout creation
+  },
+);
 
 if (!error && data?.checkoutSession.url) {
   window.location.assign(data.checkoutSession.url);
@@ -403,25 +406,23 @@ if (!error && data?.checkoutSession.url) {
 For one-time payments, `subject` is optional. For subscription checkout, `subject` is required because subscriptions represent ongoing entitlement for an app-defined billing owner.
 
 ```javascript
-await insforge.payments.createCheckoutSession("test", {
+await insforge.payments.stripe.createCheckoutSession("test", {
   mode: "subscription",
   subject: { type: "team", id: "team_123" },
-  lineItems: [{ stripePriceId: "price_monthly_123", quantity: 1 }],
+  lineItems: [{ priceId: "price_monthly_123", quantity: 1 }],
   successUrl: "https://example.com/billing/success",
   cancelUrl: "https://example.com/billing",
 });
 ```
 
-### `createCustomerPortalSession()`
+### `stripe.createCustomerPortalSession()`
 
 ```javascript
-const { data, error } = await insforge.payments.createCustomerPortalSession(
-  "test",
-  {
+const { data, error } =
+  await insforge.payments.stripe.createCustomerPortalSession("test", {
     subject: { type: "team", id: "team_123" },
     returnUrl: "https://example.com/billing",
-  },
-);
+  });
 
 if (!error && data?.customerPortalSession.url) {
   window.location.assign(data.customerPortalSession.url);
@@ -429,6 +430,83 @@ if (!error && data?.customerPortalSession.url) {
 ```
 
 Customer portal sessions require an authenticated user and an existing Stripe customer mapping for the billing subject.
+
+### `razorpay.createOrder()`
+
+Razorpay uses Checkout.js instead of a hosted redirect URL. Create an order through InsForge, pass `checkoutOptions` into Razorpay Checkout.js, then verify the signed payment response.
+
+```javascript
+const { data, error } = await insforge.payments.razorpay.createOrder("test", {
+  amount: 200000,
+  currency: "INR",
+  receipt: "cart_123",
+  subject: { type: "team", id: "team_123" },
+  customerName: "Ada Lovelace",
+  customerEmail: "ada@example.com",
+});
+
+if (!error && data) {
+  const checkout = new Razorpay({
+    ...data.checkoutOptions,
+    handler: async (response) => {
+      await insforge.payments.razorpay.verifyOrder("test", {
+        orderId: response.razorpay_order_id,
+        paymentId: response.razorpay_payment_id,
+        signature: response.razorpay_signature,
+      });
+    },
+  });
+
+  checkout.open();
+}
+```
+
+### `razorpay.createSubscription()`
+
+```javascript
+const { data, error } = await insforge.payments.razorpay.createSubscription(
+  "test",
+  {
+    planId: "plan_123",
+    totalCount: 12,
+    subject: { type: "team", id: "team_123" },
+    customerName: "Ada Lovelace",
+    customerEmail: "ada@example.com",
+  },
+);
+
+if (!error && data) {
+  const checkout = new Razorpay({
+    ...data.checkoutOptions,
+    handler: async (response) => {
+      await insforge.payments.razorpay.verifySubscription("test", {
+        subscriptionId: response.razorpay_subscription_id,
+        paymentId: response.razorpay_payment_id,
+        signature: response.razorpay_signature,
+      });
+    },
+  });
+
+  checkout.open();
+}
+```
+
+### `razorpay.cancelSubscription()`
+
+```javascript
+await insforge.payments.razorpay.cancelSubscription("test", "sub_123", {
+  cancelAtCycleEnd: false,
+});
+```
+
+### `razorpay.pauseSubscription()` / `razorpay.resumeSubscription()`
+
+```javascript
+await insforge.payments.razorpay.pauseSubscription("test", "sub_123");
+await insforge.payments.razorpay.resumeSubscription("test", "sub_123");
+```
+
+Razorpay webhook setup is manual in the Razorpay dashboard. Configure keys and copy the webhook URL, secret, and recommended events from the InsForge payments settings UI.
 
 ## Database Methods
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.3.1",
+  "version": "1.3.2-razorpay.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.3.1",
+      "version": "1.3.2-razorpay.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@insforge/shared-schemas": "^1.1.56",
+        "@insforge/shared-schemas": "^1.1.57",
         "@supabase/postgrest-js": "^1.21.3",
         "socket.io-client": "^4.8.1"
       },
@@ -690,9 +690,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.56",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.56.tgz",
-      "integrity": "sha512-x7mjHu2mLxKc2ELChRAFvTtGJGrA6GPuZ8B6F6HrfOfYcPewy2fNkVL0ySReg3x5ZLrg0LvgfH/3+pdbm+Ck9w==",
+      "version": "1.1.57",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.57.tgz",
+      "integrity": "sha512-+4OTOB4Vw5P/TmdmqKZMpLt37bU1re3R2nFDUtcEXO7+BAmTx7dTqXRAWYXR+iGamnufk7vSmO8uzJocq0a2BQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.3.2-razorpay.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.3.2-razorpay.1",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@insforge/shared-schemas": "^1.1.57",
+        "@insforge/shared-schemas": "^1.1.58",
         "@supabase/postgrest-js": "^1.21.3",
         "socket.io-client": "^4.8.1"
       },
@@ -690,9 +690,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.57",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.57.tgz",
-      "integrity": "sha512-+4OTOB4Vw5P/TmdmqKZMpLt37bU1re3R2nFDUtcEXO7+BAmTx7dTqXRAWYXR+iGamnufk7vSmO8uzJocq0a2BQ==",
+      "version": "1.1.58",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.58.tgz",
+      "integrity": "sha512-of494/PttH+nf5SBz63mAtgCBimDPIDF/tPEYb9zMNOySsGYNXYXWyqcyPuxnQcVuThlV5cdUwxW3cImvXyAvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@insforge/shared-schemas": "^1.1.55",
+        "@insforge/shared-schemas": "^1.1.56",
         "@supabase/postgrest-js": "^1.21.3",
         "socket.io-client": "^4.8.1"
       },
@@ -690,9 +690,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.55",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.55.tgz",
-      "integrity": "sha512-xor4lpP1dRiAASuQ99hl7R8pi/FAiCmN7iLLlNT5nEUvDUDbI6Ja4hJt/ElkR1jxliiMlx1u3gMMCkrWAyvJVw==",
+      "version": "1.1.56",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.56.tgz",
+      "integrity": "sha512-x7mjHu2mLxKc2ELChRAFvTtGJGrA6GPuZ8B6F6HrfOfYcPewy2fNkVL0ySReg3x5ZLrg0LvgfH/3+pdbm+Ck9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "url": "https://github.com/InsForge/insforge-sdk-js/issues"
   },
   "dependencies": {
-    "@insforge/shared-schemas": "^1.1.55",
+    "@insforge/shared-schemas": "^1.1.56",
     "@supabase/postgrest-js": "^1.21.3",
     "socket.io-client": "^4.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.3.2-razorpay.1",
+  "version": "1.4.0",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -57,7 +57,7 @@
     "url": "https://github.com/InsForge/insforge-sdk-js/issues"
   },
   "dependencies": {
-    "@insforge/shared-schemas": "^1.1.57",
+    "@insforge/shared-schemas": "^1.1.58",
     "@supabase/postgrest-js": "^1.21.3",
     "socket.io-client": "^4.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.3.1",
+  "version": "1.3.2-razorpay.1",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -57,7 +57,7 @@
     "url": "https://github.com/InsForge/insforge-sdk-js/issues"
   },
   "dependencies": {
-    "@insforge/shared-schemas": "^1.1.56",
+    "@insforge/shared-schemas": "^1.1.57",
     "@supabase/postgrest-js": "^1.21.3",
     "socket.io-client": "^4.8.1"
   },

--- a/src/modules/__tests__/payments.test.ts
+++ b/src/modules/__tests__/payments.test.ts
@@ -98,6 +98,7 @@ function razorpayOrderResponse() {
       attempts: 0,
       verifiedPaymentId: null,
       verifiedAt: null,
+      notes: {},
       lastError: null,
       createdAt: "2026-04-30T00:00:00.000Z",
       updatedAt: "2026-04-30T00:00:00.000Z",
@@ -274,11 +275,14 @@ describe("Payments", () => {
       subject: { type: "team", id: "team_123" },
       customerName: "Ada",
       customerEmail: "ada@example.com",
+      notes: { order_id: "order_123" },
     });
 
     expect(result.error).toBeNull();
     expect(result.data?.order.orderId).toBe("order_123");
     expect(result.data?.checkoutOptions.order_id).toBe("order_123");
+    expect(result.data?.checkoutOptions.key).toBe("rzp_test_123");
+    expect(result.data?.checkoutOptions.callback_url).toBeNull();
 
     const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("http://localhost:7130/api/payments/razorpay/test/orders");
@@ -287,6 +291,7 @@ describe("Payments", () => {
       amount: 200000,
       currency: "INR",
       subject: { type: "team", id: "team_123" },
+      notes: { order_id: "order_123" },
     });
     expect(JSON.parse(init.body as string)).not.toHaveProperty("environment");
   });
@@ -338,6 +343,7 @@ describe("Payments", () => {
       customerNotify: true,
       customerName: "Ada",
       customerEmail: "ada@example.com",
+      notes: { order_id: "order_123" },
     });
     const verified = await payments.razorpay.verifySubscription("test", {
       subscriptionId: "sub_123",
@@ -347,12 +353,19 @@ describe("Payments", () => {
 
     expect(created.error).toBeNull();
     expect(created.data?.checkoutOptions.subscription_id).toBe("sub_123");
+    expect(created.data?.checkoutOptions.key).toBe("rzp_test_123");
+    expect(created.data?.checkoutOptions.callback_url).toBeNull();
     expect(verified.error).toBeNull();
     expect(verified.data?.verified).toBe(true);
 
     expect(fetchFn.mock.calls[0][0]).toBe(
       "http://localhost:7130/api/payments/razorpay/test/subscriptions",
     );
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body as string)).toMatchObject({
+      planId: "plan_123",
+      subject: { type: "team", id: "team_123" },
+      notes: { order_id: "order_123" },
+    });
     expect(fetchFn.mock.calls[1][0]).toBe(
       "http://localhost:7130/api/payments/razorpay/test/subscriptions/verify",
     );
@@ -407,4 +420,77 @@ describe("Payments", () => {
       "http://localhost:7130/api/payments/razorpay/test/subscriptions/sub_123/resume",
     );
   });
+
+  it.each([
+    {
+      method: "createOrder",
+      fallbackMessage: "Razorpay order creation failed",
+      call: (payments: Payments) =>
+        payments.razorpay.createOrder("test", {
+          amount: 200000,
+          currency: "INR",
+        }),
+    },
+    {
+      method: "verifyOrder",
+      fallbackMessage: "Razorpay order verification failed",
+      call: (payments: Payments) =>
+        payments.razorpay.verifyOrder("test", {
+          orderId: "order_123",
+          paymentId: "pay_123",
+          signature: "sig_123",
+        }),
+    },
+    {
+      method: "createSubscription",
+      fallbackMessage: "Razorpay subscription creation failed",
+      call: (payments: Payments) =>
+        payments.razorpay.createSubscription("test", {
+          planId: "plan_123",
+          totalCount: 12,
+        }),
+    },
+    {
+      method: "verifySubscription",
+      fallbackMessage: "Razorpay subscription verification failed",
+      call: (payments: Payments) =>
+        payments.razorpay.verifySubscription("test", {
+          subscriptionId: "sub_123",
+          paymentId: "pay_123",
+          signature: "sig_123",
+        }),
+    },
+    {
+      method: "cancelSubscription",
+      fallbackMessage: "Razorpay subscription cancellation failed",
+      call: (payments: Payments) =>
+        payments.razorpay.cancelSubscription("test", "sub_123"),
+    },
+    {
+      method: "pauseSubscription",
+      fallbackMessage: "Razorpay subscription pause failed",
+      call: (payments: Payments) =>
+        payments.razorpay.pauseSubscription("test", "sub_123"),
+    },
+    {
+      method: "resumeSubscription",
+      fallbackMessage: "Razorpay subscription resume failed",
+      call: (payments: Payments) =>
+        payments.razorpay.resumeSubscription("test", "sub_123"),
+    },
+  ])(
+    "surfaces $method unexpected errors as InsForgeError values",
+    async ({ call, fallbackMessage }) => {
+      const post = vi.fn().mockRejectedValue("unexpected failure");
+      const payments = new Payments({ post } as unknown as HttpClient);
+
+      const result = await call(payments);
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeInstanceOf(InsForgeError);
+      expect(result.error?.error).toBe("UNEXPECTED_ERROR");
+      expect(result.error?.statusCode).toBe(500);
+      expect(result.error?.message).toBe(fallbackMessage);
+    },
+  );
 });

--- a/src/modules/__tests__/payments.test.ts
+++ b/src/modules/__tests__/payments.test.ts
@@ -103,11 +103,10 @@ function razorpayOrderResponse() {
       updatedAt: "2026-04-30T00:00:00.000Z",
     },
     checkoutOptions: {
-      keyId: "rzp_test_123",
+      key: "rzp_test_123",
       amount: 200000,
       currency: "INR",
-      orderId: "order_123",
-      subscriptionId: null,
+      order_id: "order_123",
       name: null,
       description: null,
       prefill: {
@@ -115,7 +114,7 @@ function razorpayOrderResponse() {
         email: "ada@example.com",
         contact: null,
       },
-      callbackUrl: null,
+      callback_url: null,
     },
   };
 }
@@ -156,11 +155,10 @@ function razorpaySubscriptionResponse(status = "created") {
       updatedAt: "2026-04-30T00:00:00.000Z",
     },
     checkoutOptions: {
-      keyId: "rzp_test_123",
+      key: "rzp_test_123",
       amount: undefined,
       currency: undefined,
-      orderId: null,
-      subscriptionId: "sub_123",
+      subscription_id: "sub_123",
       name: null,
       description: null,
       prefill: {
@@ -168,7 +166,7 @@ function razorpaySubscriptionResponse(status = "created") {
         email: "ada@example.com",
         contact: null,
       },
-      callbackUrl: null,
+      callback_url: null,
     },
   };
 }
@@ -280,7 +278,7 @@ describe("Payments", () => {
 
     expect(result.error).toBeNull();
     expect(result.data?.order.orderId).toBe("order_123");
-    expect(result.data?.checkoutOptions.orderId).toBe("order_123");
+    expect(result.data?.checkoutOptions.order_id).toBe("order_123");
 
     const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("http://localhost:7130/api/payments/razorpay/test/orders");
@@ -348,7 +346,7 @@ describe("Payments", () => {
     });
 
     expect(created.error).toBeNull();
-    expect(created.data?.checkoutOptions.subscriptionId).toBe("sub_123");
+    expect(created.data?.checkoutOptions.subscription_id).toBe("sub_123");
     expect(verified.error).toBeNull();
     expect(verified.data?.verified).toBe(true);
 

--- a/src/modules/__tests__/payments.test.ts
+++ b/src/modules/__tests__/payments.test.ts
@@ -45,10 +45,10 @@ function checkoutResponse(url = "https://checkout.stripe.com/c/session_123") {
       subjectType: null,
       subjectId: null,
       customerEmail: null,
-      stripeCheckoutSessionId: "cs_test_123",
-      stripeCustomerId: null,
-      stripePaymentIntentId: null,
-      stripeSubscriptionId: null,
+      checkoutSessionId: "cs_test_123",
+      customerId: null,
+      paymentIntentId: null,
+      subscriptionId: null,
       url,
       lastError: null,
       createdAt: "2026-04-30T00:00:00.000Z",
@@ -67,7 +67,7 @@ function customerPortalResponse(
       status: "created",
       subjectType: "team",
       subjectId: "team_123",
-      stripeCustomerId: "cus_123",
+      customerId: "cus_123",
       returnUrl: "https://app.example.com/account",
       configuration: null,
       url,
@@ -78,28 +78,129 @@ function customerPortalResponse(
   };
 }
 
+function razorpayOrderResponse() {
+  return {
+    order: {
+      id: "local_order_123",
+      environment: "test",
+      status: "created",
+      subjectType: "team",
+      subjectId: "team_123",
+      customerName: "Ada",
+      customerEmail: "ada@example.com",
+      customerContact: null,
+      orderId: "order_123",
+      receipt: "receipt_123",
+      amount: 200000,
+      amountPaid: 0,
+      amountDue: 200000,
+      currency: "INR",
+      attempts: 0,
+      verifiedPaymentId: null,
+      verifiedAt: null,
+      lastError: null,
+      createdAt: "2026-04-30T00:00:00.000Z",
+      updatedAt: "2026-04-30T00:00:00.000Z",
+    },
+    checkoutOptions: {
+      keyId: "rzp_test_123",
+      amount: 200000,
+      currency: "INR",
+      orderId: "order_123",
+      subscriptionId: null,
+      name: null,
+      description: null,
+      prefill: {
+        name: "Ada",
+        email: "ada@example.com",
+        contact: null,
+      },
+      callbackUrl: null,
+    },
+  };
+}
+
+function razorpaySubscriptionResponse(status = "created") {
+  return {
+    subscription: {
+      id: "local_subscription_123",
+      environment: "test",
+      subscriptionId: "sub_123",
+      planId: "plan_123",
+      customerId: null,
+      subjectType: "team",
+      subjectId: "team_123",
+      status,
+      quantity: 1,
+      totalCount: 12,
+      paidCount: 0,
+      remainingCount: 12,
+      currentStart: null,
+      currentEnd: null,
+      endedAt: null,
+      chargeAt: null,
+      startAt: null,
+      endAt: null,
+      authAttempts: 0,
+      expireBy: null,
+      customerNotify: true,
+      offerId: null,
+      shortUrl: "https://rzp.io/i/sub_123",
+      hasScheduledChanges: false,
+      changeScheduledAt: null,
+      authorizationPaymentId: null,
+      notes: {},
+      providerCreatedAt: "2026-04-30T00:00:00.000Z",
+      syncedAt: "2026-04-30T00:00:00.000Z",
+      createdAt: "2026-04-30T00:00:00.000Z",
+      updatedAt: "2026-04-30T00:00:00.000Z",
+    },
+    checkoutOptions: {
+      keyId: "rzp_test_123",
+      amount: undefined,
+      currency: undefined,
+      orderId: null,
+      subscriptionId: "sub_123",
+      name: null,
+      description: null,
+      prefill: {
+        name: "Ada",
+        email: "ada@example.com",
+        contact: null,
+      },
+      callbackUrl: null,
+    },
+  };
+}
+
 describe("Payments", () => {
-  it("creates a checkout session through the payments runtime route", async () => {
+  it("exposes provider-scoped payments clients", () => {
+    const payments = new Payments(makeHttp(vi.fn()));
+
+    expect(payments.stripe).toBeDefined();
+    expect(payments.razorpay).toBeDefined();
+    expect("createCheckoutSession" in payments).toBe(false);
+  });
+
+  it("creates a Stripe checkout session through the provider-scoped runtime route", async () => {
     const fetchFn = vi.fn().mockResolvedValue(jsonRes(201, checkoutResponse()));
     const payments = new Payments(makeHttp(fetchFn));
 
-    const result = await payments.createCheckoutSession("test", {
+    const result = await payments.stripe.createCheckoutSession("test", {
       mode: "payment",
-      lineItems: [{ stripePriceId: "price_123", quantity: 1 }],
+      lineItems: [{ priceId: "price_123", quantity: 1 }],
       successUrl: "https://app.example.com/success",
       cancelUrl: "https://app.example.com/pricing",
       idempotencyKey: "cart_123",
     });
 
     expect(result.error).toBeNull();
-    expect(result.data?.checkoutSession.stripeCheckoutSessionId).toBe(
-      "cs_test_123",
-    );
+    expect(result.data?.checkoutSession.checkoutSessionId).toBe("cs_test_123");
     expect(fetchFn).toHaveBeenCalledOnce();
 
     const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(
-      "http://localhost:7130/api/payments/test/checkout-sessions",
+      "http://localhost:7130/api/payments/stripe/test/checkout-sessions",
     );
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body as string)).toMatchObject({
@@ -109,7 +210,7 @@ describe("Payments", () => {
     expect(JSON.parse(init.body as string)).not.toHaveProperty("environment");
   });
 
-  it("surfaces checkout API errors as InsForgeError values", async () => {
+  it("surfaces Stripe checkout API errors as InsForgeError values", async () => {
     const fetchFn = vi
       .fn()
       .mockResolvedValue(
@@ -121,9 +222,9 @@ describe("Payments", () => {
       );
     const payments = new Payments(makeHttp(fetchFn));
 
-    const result = await payments.createCheckoutSession("test", {
+    const result = await payments.stripe.createCheckoutSession("test", {
       mode: "payment",
-      lineItems: [{ stripePriceId: "price_123", quantity: 1 }],
+      lineItems: [{ priceId: "price_123", quantity: 1 }],
       successUrl: "https://app.example.com/success",
       cancelUrl: "https://app.example.com/pricing",
     });
@@ -134,13 +235,13 @@ describe("Payments", () => {
     expect(result.error?.message).toBe("Bad checkout");
   });
 
-  it("creates a customer portal session through the payments runtime route", async () => {
+  it("creates a Stripe customer portal session through the provider-scoped runtime route", async () => {
     const fetchFn = vi
       .fn()
       .mockResolvedValue(jsonRes(201, customerPortalResponse()));
     const payments = new Payments(makeHttp(fetchFn));
 
-    const result = await payments.createCustomerPortalSession("test", {
+    const result = await payments.stripe.createCustomerPortalSession("test", {
       subject: { type: "team", id: "team_123" },
       returnUrl: "https://app.example.com/account",
     });
@@ -153,12 +254,159 @@ describe("Payments", () => {
 
     const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(
-      "http://localhost:7130/api/payments/test/customer-portal-sessions",
+      "http://localhost:7130/api/payments/stripe/test/customer-portal-sessions",
     );
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body as string)).toMatchObject({
       subject: { type: "team", id: "team_123" },
     });
     expect(JSON.parse(init.body as string)).not.toHaveProperty("environment");
+  });
+
+  it("creates a Razorpay order and returns Checkout.js options", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonRes(201, razorpayOrderResponse()));
+    const payments = new Payments(makeHttp(fetchFn));
+
+    const result = await payments.razorpay.createOrder("test", {
+      amount: 200000,
+      currency: "INR",
+      receipt: "receipt_123",
+      subject: { type: "team", id: "team_123" },
+      customerName: "Ada",
+      customerEmail: "ada@example.com",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.order.orderId).toBe("order_123");
+    expect(result.data?.checkoutOptions.orderId).toBe("order_123");
+
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:7130/api/payments/razorpay/test/orders");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      amount: 200000,
+      currency: "INR",
+      subject: { type: "team", id: "team_123" },
+    });
+    expect(JSON.parse(init.body as string)).not.toHaveProperty("environment");
+  });
+
+  it("verifies a Razorpay order payment signature", async () => {
+    const response = {
+      verified: true,
+      order: razorpayOrderResponse().order,
+    };
+    const fetchFn = vi.fn().mockResolvedValue(jsonRes(200, response));
+    const payments = new Payments(makeHttp(fetchFn));
+
+    const result = await payments.razorpay.verifyOrder("test", {
+      orderId: "order_123",
+      paymentId: "pay_123",
+      signature: "sig_123",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.verified).toBe(true);
+
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "http://localhost:7130/api/payments/razorpay/test/orders/verify",
+    );
+    expect(JSON.parse(init.body as string)).toEqual({
+      orderId: "order_123",
+      paymentId: "pay_123",
+      signature: "sig_123",
+    });
+  });
+
+  it("creates and verifies a Razorpay subscription", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(201, razorpaySubscriptionResponse()))
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          verified: true,
+          subscription: razorpaySubscriptionResponse("active").subscription,
+        }),
+      );
+    const payments = new Payments(makeHttp(fetchFn));
+
+    const created = await payments.razorpay.createSubscription("test", {
+      planId: "plan_123",
+      totalCount: 12,
+      subject: { type: "team", id: "team_123" },
+      customerNotify: true,
+      customerName: "Ada",
+      customerEmail: "ada@example.com",
+    });
+    const verified = await payments.razorpay.verifySubscription("test", {
+      subscriptionId: "sub_123",
+      paymentId: "pay_123",
+      signature: "sig_123",
+    });
+
+    expect(created.error).toBeNull();
+    expect(created.data?.checkoutOptions.subscriptionId).toBe("sub_123");
+    expect(verified.error).toBeNull();
+    expect(verified.data?.verified).toBe(true);
+
+    expect(fetchFn.mock.calls[0][0]).toBe(
+      "http://localhost:7130/api/payments/razorpay/test/subscriptions",
+    );
+    expect(fetchFn.mock.calls[1][0]).toBe(
+      "http://localhost:7130/api/payments/razorpay/test/subscriptions/verify",
+    );
+  });
+
+  it("manages Razorpay subscriptions through native lifecycle routes", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          subscription: razorpaySubscriptionResponse("cancelled").subscription,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          subscription: razorpaySubscriptionResponse("cancelled").subscription,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          subscription: razorpaySubscriptionResponse("paused").subscription,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          subscription: razorpaySubscriptionResponse("active").subscription,
+        }),
+      );
+    const payments = new Payments(makeHttp(fetchFn));
+
+    await payments.razorpay.cancelSubscription("test", "sub_123");
+    await payments.razorpay.cancelSubscription("test", "sub_123", {
+      cancelAtCycleEnd: true,
+    });
+    await payments.razorpay.pauseSubscription("test", "sub_123");
+    await payments.razorpay.resumeSubscription("test", "sub_123");
+
+    expect(fetchFn.mock.calls[0][0]).toBe(
+      "http://localhost:7130/api/payments/razorpay/test/subscriptions/sub_123/cancel",
+    );
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body as string)).toEqual({});
+    expect(fetchFn.mock.calls[1][0]).toBe(
+      "http://localhost:7130/api/payments/razorpay/test/subscriptions/sub_123/cancel",
+    );
+    expect(JSON.parse(fetchFn.mock.calls[1][1].body as string)).toEqual({
+      cancelAtCycleEnd: true,
+    });
+    expect(fetchFn.mock.calls[2][0]).toBe(
+      "http://localhost:7130/api/payments/razorpay/test/subscriptions/sub_123/pause",
+    );
+    expect(fetchFn.mock.calls[3][0]).toBe(
+      "http://localhost:7130/api/payments/razorpay/test/subscriptions/sub_123/resume",
+    );
   });
 });

--- a/src/modules/payments.ts
+++ b/src/modules/payments.ts
@@ -1,16 +1,32 @@
 import { HttpClient } from "../lib/http-client";
 import { wrapError } from "./auth/helpers";
 import type { InsForgeError } from "../types";
+import type { cancelRazorpaySubscriptionBodySchema } from "@insforge/shared-schemas";
 import type {
+  CancelRazorpaySubscriptionResponse,
   CreateCheckoutSessionBody,
   CreateCheckoutSessionResponse,
   CreateCustomerPortalSessionBody,
   CreateCustomerPortalSessionResponse,
+  CreateRazorpayOrderBody,
+  CreateRazorpayOrderResponse,
+  CreateRazorpaySubscriptionBody,
+  CreateRazorpaySubscriptionResponse,
+  PauseRazorpaySubscriptionResponse,
+  RazorpayEnvironment,
+  ResumeRazorpaySubscriptionResponse,
   StripeEnvironment,
+  VerifyRazorpayOrderBody,
+  VerifyRazorpayOrderResponse,
+  VerifyRazorpaySubscriptionBody,
+  VerifyRazorpaySubscriptionResponse,
 } from "@insforge/shared-schemas";
 
 export type {
   BillingSubject,
+  CancelRazorpaySubscriptionBody,
+  CancelRazorpaySubscriptionRequest,
+  CancelRazorpaySubscriptionResponse,
   CheckoutMode,
   CheckoutSession,
   CheckoutSessionPaymentStatus,
@@ -20,9 +36,24 @@ export type {
   CreateCheckoutSessionResponse,
   CreateCustomerPortalSessionBody,
   CreateCustomerPortalSessionResponse,
+  CreateRazorpayOrderBody,
+  CreateRazorpayOrderResponse,
+  CreateRazorpaySubscriptionBody,
+  CreateRazorpaySubscriptionResponse,
   CustomerPortalSession,
   CustomerPortalSessionStatus,
+  PauseRazorpaySubscriptionResponse,
+  RazorpayEnvironment,
+  RazorpayOrder,
+  RazorpayOrderStatus,
+  RazorpaySubscription,
+  RazorpaySubscriptionStatus,
+  ResumeRazorpaySubscriptionResponse,
   StripeEnvironment,
+  VerifyRazorpayOrderBody,
+  VerifyRazorpayOrderResponse,
+  VerifyRazorpaySubscriptionBody,
+  VerifyRazorpaySubscriptionResponse,
 } from "@insforge/shared-schemas";
 
 export interface PaymentsResponse<T> {
@@ -30,14 +61,24 @@ export interface PaymentsResponse<T> {
   error: InsForgeError | null;
 }
 
+type CancelRazorpaySubscriptionBodyInput =
+  (typeof cancelRazorpaySubscriptionBodySchema)["_input"];
+
+function providerEnvironmentPath(
+  provider: "stripe" | "razorpay",
+  environment: string,
+): string {
+  return `/api/payments/${provider}/${encodeURIComponent(environment)}`;
+}
+
 /**
- * Payments client for runtime Stripe payment flows.
+ * Stripe runtime payment flows.
  *
  * These methods are safe to call from generated app frontends with the current
  * user token or anon key. Admin-only Stripe key/catalog APIs are intentionally
  * not exposed here.
  */
-export class Payments {
+export class StripePayments {
   constructor(private http: HttpClient) {}
 
   /**
@@ -45,9 +86,9 @@ export class Payments {
    *
    * @example
    * ```typescript
-   * const { data, error } = await client.payments.createCheckoutSession('test', {
+   * const { data, error } = await client.payments.stripe.createCheckoutSession('test', {
    *   mode: 'payment',
-   *   lineItems: [{ stripePriceId: 'price_123', quantity: 1 }],
+   *   lineItems: [{ priceId: 'price_123', quantity: 1 }],
    *   successUrl: `${window.location.origin}/success`,
    *   cancelUrl: `${window.location.origin}/pricing`
    * });
@@ -63,7 +104,7 @@ export class Payments {
   ): Promise<PaymentsResponse<CreateCheckoutSessionResponse>> {
     try {
       const data = await this.http.post<CreateCheckoutSessionResponse>(
-        `/api/payments/${encodeURIComponent(environment)}/checkout-sessions`,
+        `${providerEnvironmentPath("stripe", environment)}/checkout-sessions`,
         request,
         { idempotent: !!request.idempotencyKey },
       );
@@ -72,7 +113,7 @@ export class Payments {
     } catch (error) {
       return wrapError<CreateCheckoutSessionResponse>(
         error,
-        "Checkout session creation failed",
+        "Stripe checkout session creation failed",
       );
     }
   }
@@ -86,7 +127,7 @@ export class Payments {
   ): Promise<PaymentsResponse<CreateCustomerPortalSessionResponse>> {
     try {
       const data = await this.http.post<CreateCustomerPortalSessionResponse>(
-        `/api/payments/${encodeURIComponent(environment)}/customer-portal-sessions`,
+        `${providerEnvironmentPath("stripe", environment)}/customer-portal-sessions`,
         request,
       );
 
@@ -94,8 +135,172 @@ export class Payments {
     } catch (error) {
       return wrapError<CreateCustomerPortalSessionResponse>(
         error,
-        "Customer portal session creation failed",
+        "Stripe customer portal session creation failed",
       );
     }
+  }
+}
+
+/**
+ * Razorpay runtime payment flows.
+ *
+ * Razorpay Checkout is client-rendered: create an order or subscription here,
+ * pass the returned checkoutOptions to Razorpay Checkout.js, then verify the
+ * signed payment response with the matching verify method.
+ */
+export class RazorpayPayments {
+  constructor(private http: HttpClient) {}
+
+  async createOrder(
+    environment: RazorpayEnvironment,
+    request: CreateRazorpayOrderBody,
+  ): Promise<PaymentsResponse<CreateRazorpayOrderResponse>> {
+    try {
+      const data = await this.http.post<CreateRazorpayOrderResponse>(
+        `${providerEnvironmentPath("razorpay", environment)}/orders`,
+        request,
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return wrapError<CreateRazorpayOrderResponse>(
+        error,
+        "Razorpay order creation failed",
+      );
+    }
+  }
+
+  async verifyOrder(
+    environment: RazorpayEnvironment,
+    request: VerifyRazorpayOrderBody,
+  ): Promise<PaymentsResponse<VerifyRazorpayOrderResponse>> {
+    try {
+      const data = await this.http.post<VerifyRazorpayOrderResponse>(
+        `${providerEnvironmentPath("razorpay", environment)}/orders/verify`,
+        request,
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return wrapError<VerifyRazorpayOrderResponse>(
+        error,
+        "Razorpay order verification failed",
+      );
+    }
+  }
+
+  async createSubscription(
+    environment: RazorpayEnvironment,
+    request: CreateRazorpaySubscriptionBody,
+  ): Promise<PaymentsResponse<CreateRazorpaySubscriptionResponse>> {
+    try {
+      const data = await this.http.post<CreateRazorpaySubscriptionResponse>(
+        `${providerEnvironmentPath("razorpay", environment)}/subscriptions`,
+        request,
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return wrapError<CreateRazorpaySubscriptionResponse>(
+        error,
+        "Razorpay subscription creation failed",
+      );
+    }
+  }
+
+  async verifySubscription(
+    environment: RazorpayEnvironment,
+    request: VerifyRazorpaySubscriptionBody,
+  ): Promise<PaymentsResponse<VerifyRazorpaySubscriptionResponse>> {
+    try {
+      const data = await this.http.post<VerifyRazorpaySubscriptionResponse>(
+        `${providerEnvironmentPath("razorpay", environment)}/subscriptions/verify`,
+        request,
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return wrapError<VerifyRazorpaySubscriptionResponse>(
+        error,
+        "Razorpay subscription verification failed",
+      );
+    }
+  }
+
+  async cancelSubscription(
+    environment: RazorpayEnvironment,
+    subscriptionId: string,
+    request: CancelRazorpaySubscriptionBodyInput = {},
+  ): Promise<PaymentsResponse<CancelRazorpaySubscriptionResponse>> {
+    try {
+      const data = await this.http.post<CancelRazorpaySubscriptionResponse>(
+        `${providerEnvironmentPath("razorpay", environment)}/subscriptions/${encodeURIComponent(
+          subscriptionId,
+        )}/cancel`,
+        request,
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return wrapError<CancelRazorpaySubscriptionResponse>(
+        error,
+        "Razorpay subscription cancellation failed",
+      );
+    }
+  }
+
+  async pauseSubscription(
+    environment: RazorpayEnvironment,
+    subscriptionId: string,
+  ): Promise<PaymentsResponse<PauseRazorpaySubscriptionResponse>> {
+    try {
+      const data = await this.http.post<PauseRazorpaySubscriptionResponse>(
+        `${providerEnvironmentPath("razorpay", environment)}/subscriptions/${encodeURIComponent(
+          subscriptionId,
+        )}/pause`,
+        {},
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return wrapError<PauseRazorpaySubscriptionResponse>(
+        error,
+        "Razorpay subscription pause failed",
+      );
+    }
+  }
+
+  async resumeSubscription(
+    environment: RazorpayEnvironment,
+    subscriptionId: string,
+  ): Promise<PaymentsResponse<ResumeRazorpaySubscriptionResponse>> {
+    try {
+      const data = await this.http.post<ResumeRazorpaySubscriptionResponse>(
+        `${providerEnvironmentPath("razorpay", environment)}/subscriptions/${encodeURIComponent(
+          subscriptionId,
+        )}/resume`,
+        {},
+      );
+
+      return { data, error: null };
+    } catch (error) {
+      return wrapError<ResumeRazorpaySubscriptionResponse>(
+        error,
+        "Razorpay subscription resume failed",
+      );
+    }
+  }
+}
+
+/**
+ * Provider-scoped payments client.
+ */
+export class Payments {
+  public readonly stripe: StripePayments;
+  public readonly razorpay: RazorpayPayments;
+
+  constructor(http: HttpClient) {
+    this.stripe = new StripePayments(http);
+    this.razorpay = new RazorpayPayments(http);
   }
 }

--- a/src/modules/payments.ts
+++ b/src/modules/payments.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from "../lib/http-client";
 import { wrapError } from "./auth/helpers";
 import type { InsForgeError } from "../types";
-import type { cancelRazorpaySubscriptionBodySchema } from "@insforge/shared-schemas";
 import type {
+  CancelRazorpaySubscriptionBodyInput,
   CancelRazorpaySubscriptionResponse,
   CreateCheckoutSessionBody,
   CreateCheckoutSessionResponse,
@@ -14,40 +14,6 @@ import type {
   CreateRazorpaySubscriptionResponse,
   PauseRazorpaySubscriptionResponse,
   RazorpayEnvironment,
-  ResumeRazorpaySubscriptionResponse,
-  StripeEnvironment,
-  VerifyRazorpayOrderBody,
-  VerifyRazorpayOrderResponse,
-  VerifyRazorpaySubscriptionBody,
-  VerifyRazorpaySubscriptionResponse,
-} from "@insforge/shared-schemas";
-
-export type {
-  BillingSubject,
-  CancelRazorpaySubscriptionBody,
-  CancelRazorpaySubscriptionRequest,
-  CancelRazorpaySubscriptionResponse,
-  CheckoutMode,
-  CheckoutSession,
-  CheckoutSessionPaymentStatus,
-  CheckoutSessionStatus,
-  CreateCheckoutSessionBody,
-  CreateCheckoutSessionLineItem,
-  CreateCheckoutSessionResponse,
-  CreateCustomerPortalSessionBody,
-  CreateCustomerPortalSessionResponse,
-  CreateRazorpayOrderBody,
-  CreateRazorpayOrderResponse,
-  CreateRazorpaySubscriptionBody,
-  CreateRazorpaySubscriptionResponse,
-  CustomerPortalSession,
-  CustomerPortalSessionStatus,
-  PauseRazorpaySubscriptionResponse,
-  RazorpayEnvironment,
-  RazorpayOrder,
-  RazorpayOrderStatus,
-  RazorpaySubscription,
-  RazorpaySubscriptionStatus,
   ResumeRazorpaySubscriptionResponse,
   StripeEnvironment,
   VerifyRazorpayOrderBody,
@@ -60,9 +26,6 @@ export interface PaymentsResponse<T> {
   data: T | null;
   error: InsForgeError | null;
 }
-
-type CancelRazorpaySubscriptionBodyInput =
-  (typeof cancelRazorpaySubscriptionBodySchema)["_input"];
 
 function providerEnvironmentPath(
   provider: "stripe" | "razorpay",


### PR DESCRIPTION
## Summary

- Rework the payments SDK into provider-scoped submodules: `payments.stripe` and `payments.razorpay`
- Add Razorpay runtime order, subscription, verification, and subscription lifecycle helpers
- Update payment docs/examples to use provider-specific APIs and `@insforge/shared-schemas@^1.1.56`
- Expand payments unit coverage for the new Stripe and Razorpay route contracts

## Notes

- This intentionally removes the old root-level `payments.createCheckoutSession` style API.
- Admin-only payment configuration, catalog, sync, webhook, customer, and transaction APIs remain outside the frontend SDK surface.

## Verification

- `npx prettier --check src/modules/payments.ts src/modules/__tests__/payments.test.ts README.md SDK-REFERENCE.md package.json package-lock.json`
- `npm run typecheck`
- `npm run build`
- `npm run test:run -- --coverage`
- `git diff --check`
- Stale API scan for `payments.create`, `stripePriceId`, `stripeCheckoutSessionId`, and `stripeCustomerId`

## Known repo issue

- `npm run lint` currently fails because this SDK repository has no ESLint configuration file. The PR CI does not include a lint job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider-scoped payments clients with `payments.stripe` and `payments.razorpay`, introducing Razorpay order/subscription flows and moving Stripe to provider-scoped routes. Removes the old root-level Stripe methods and updates docs/examples.

- **New Features**
  - Provider-scoped modules and routes: `payments.stripe` and `payments.razorpay`.
  - Razorpay: `createOrder`, `verifyOrder`, `createSubscription`, `verifySubscription`, plus `cancel/pause/resume`; responses include `checkoutOptions` for Checkout.js.
  - Stripe responses now use generic fields: `checkoutSessionId`, `customerId`, `paymentIntentId`, `subscriptionId`.
  - Updated README and SDK reference with provider APIs and Razorpay Checkout.js flows; bumped `@insforge/shared-schemas` to `^1.1.58`; package version `1.4.0`.
  - Expanded unit tests for Stripe and Razorpay provider routes.

- **Migration**
  - Replace `payments.createCheckoutSession()` with `payments.stripe.createCheckoutSession()`.
  - Replace `payments.createCustomerPortalSession()` with `payments.stripe.createCustomerPortalSession()`.
  - Rename `stripePriceId` to `priceId` in line items.
  - Update references from `stripe*` response fields to `checkoutSessionId`, `customerId`, `paymentIntentId`, `subscriptionId`.

<sup>Written for commit 5914b7622cf66defc9c23e26aa14923843a72dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider-scoped Razorpay payments SDK with refactored Stripe client
> - Refactors the `Payments` class into a provider-scoped aggregator exposing `payments.stripe.*` and `payments.razorpay.*` sub-clients, removing top-level `createCheckoutSession` and `createCustomerPortalSession` methods.
> - Adds `RazorpayPayments` with `createOrder`, `verifyOrder`, `createSubscription`, `verifySubscription`, `cancelSubscription`, `pauseSubscription`, and `resumeSubscription`, all posting to `/api/payments/razorpay/{env}/...`.
> - Updates Stripe endpoints from `/api/payments/{env}/...` to `/api/payments/stripe/{env}/...` and renames the `stripePriceId` line item field to `priceId`.
> - Behavioral Change: existing callers using `payments.createCheckoutSession(...)` or `payments.createCustomerPortalSession(...)` will break; they must migrate to `payments.stripe.*`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #92 opened
>
> - Added error handling to surface unexpected HTTP client rejections in seven Razorpay methods [5914b76]
> - Refactored Razorpay type imports to use direct imports and removed type re-exports [5914b76]
> - Added notes parameter support to Razorpay order and subscription creation [5914b76]
> - Bumped package version and updated dependencies [5914b76]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0dca42.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payments SDK now exposes provider-scoped Stripe and Razorpay surfaces; Razorpay adds order flows and full subscription lifecycle (create, verify, cancel, pause, resume). Stripe checkout and customer-portal flows streamlined.

* **Documentation**
  * README and SDK docs updated with provider-scoped examples, Stripe checkout/subscription examples, priceId usage in line items, and Razorpay integration guidance (checkout options, verification, webhook setup).

* **Tests**
  * Expanded tests for provider-scoped behavior and error handling.

* **Chores**
  * Package version bumped and shared-schemas dependency updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->