### PR TITLE
fix(auth): send X-CSRF-Token header on browser logout

### DIFF
--- a/src/modules/auth/__tests__/auth.test.ts
+++ b/src/modules/auth/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HttpClient } from '../../../lib/http-client';
 import { TokenManager } from '../../../lib/token-manager';
 import * as tokenManagerModule from '../../../lib/token-manager';
@@ -30,6 +30,9 @@ function createJsonResponse(status: number, body: any): Response {
 }
 
 describe('Auth', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   describe('signInWithOAuth()', () => {
     it('sends provider-specific additionalParams during OAuth init', async () => {
       const fetchMock = vi.fn().mockResolvedValue(
@@ -223,13 +226,11 @@ describe('Auth', () => {
 
       expect(error).toBeNull();
       expect(fetchMock).toHaveBeenCalled();
-      
-      const lastCall = fetchMock.mock.calls[0];
-      const requestUrl = lastCall[0] as string;
-      const requestInit = lastCall[1] as RequestInit;
-      
+
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+
       expect(requestUrl).toContain('/api/auth/logout');
-      
+
       const headers = new Headers(requestInit.headers);
       expect(headers.get('X-CSRF-Token')).toBe('test-csrf-token-abc');
     });
@@ -253,13 +254,11 @@ describe('Auth', () => {
 
       expect(error).toBeNull();
       expect(fetchMock).toHaveBeenCalled();
-      
-      const lastCall = fetchMock.mock.calls[0];
-      const requestUrl = lastCall[0] as string;
-      const requestInit = lastCall[1] as RequestInit;
-      
+
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+
       expect(requestUrl).toContain('/api/auth/logout');
-      
+
       const headers = new Headers(requestInit.headers);
       expect(headers.has('X-CSRF-Token')).toBe(false);
     });

--- a/src/modules/auth/__tests__/auth.test.ts
+++ b/src/modules/auth/__tests__/auth.test.ts
@@ -262,5 +262,33 @@ describe('Auth', () => {
       const headers = new Headers(requestInit.headers);
       expect(headers.has('X-CSRF-Token')).toBe(false);
     });
+
+    it('does not send X-CSRF-Token header in browser mode when CSRF token is null', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(createJsonResponse(200, { success: true }));
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: false });
+
+      vi.spyOn(tokenManagerModule, 'getCsrfToken').mockReturnValue(null);
+
+      const { error } = await auth.signOut();
+
+      expect(error).toBeNull();
+      expect(fetchMock).toHaveBeenCalled();
+
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+      expect(requestUrl).toContain('/api/auth/logout');
+
+      const headers = new Headers(requestInit.headers);
+      expect(headers.has('X-CSRF-Token')).toBe(false);
+    });
   });
 });

--- a/src/modules/auth/__tests__/auth.test.ts
+++ b/src/modules/auth/__tests__/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { HttpClient } from '../../../lib/http-client';
 import { TokenManager } from '../../../lib/token-manager';
+import * as tokenManagerModule from '../../../lib/token-manager';
 import { Auth } from '../auth';
 
 vi.mock('../helpers', async (importOriginal) => {
@@ -199,6 +200,68 @@ describe('Auth', () => {
       expect(error?.statusCode).toBe(400);
       expect(error?.error).toBe('INVALID_INPUT');
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('signOut()', () => {
+    it('sends X-CSRF-Token header during browser logout when CSRF token is present', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(createJsonResponse(200, { success: true }));
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: false });
+
+      vi.spyOn(tokenManagerModule, 'getCsrfToken').mockReturnValue('test-csrf-token-abc');
+
+      const { error } = await auth.signOut();
+
+      expect(error).toBeNull();
+      expect(fetchMock).toHaveBeenCalled();
+      
+      const lastCall = fetchMock.mock.calls[0];
+      const requestUrl = lastCall[0] as string;
+      const requestInit = lastCall[1] as RequestInit;
+      
+      expect(requestUrl).toContain('/api/auth/logout');
+      
+      const headers = new Headers(requestInit.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('test-csrf-token-abc');
+    });
+
+    it('does not send X-CSRF-Token header in server mode', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(createJsonResponse(200, { success: true }));
+      const http = new HttpClient(
+        {
+          baseUrl: 'http://localhost:7130',
+          fetch: fetchMock as any,
+          retryCount: 0,
+          timeout: 0,
+        },
+        new TokenManager(),
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      vi.spyOn(tokenManagerModule, 'getCsrfToken').mockReturnValue('test-csrf-token-abc');
+
+      const { error } = await auth.signOut();
+
+      expect(error).toBeNull();
+      expect(fetchMock).toHaveBeenCalled();
+      
+      const lastCall = fetchMock.mock.calls[0];
+      const requestUrl = lastCall[0] as string;
+      const requestInit = lastCall[1] as RequestInit;
+      
+      expect(requestUrl).toContain('/api/auth/logout');
+      
+      const headers = new Headers(requestInit.headers);
+      expect(headers.has('X-CSRF-Token')).toBe(false);
     });
   });
 });

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -200,16 +200,17 @@ export class Auth {
     try {
       // Try backend logout first
       try {
-        const csrfToken = !this.isServerMode() ? getCsrfToken() : null;
+        const serverMode = this.isServerMode();
+        const csrfToken = !serverMode ? getCsrfToken() : null;
         await this.http.post(
-          this.isServerMode()
+          serverMode
             ? '/api/auth/logout?client_type=mobile'
             : '/api/auth/logout',
           undefined,
           {
             credentials: 'include',
             skipAuthRefresh: true,
-            headers: csrfToken ? { 'X-CSRF-Token': csrfToken } : {},
+            ...(csrfToken ? { headers: { 'X-CSRF-Token': csrfToken } } : {}),
           },
         );
       } catch {

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -200,12 +200,17 @@ export class Auth {
     try {
       // Try backend logout first
       try {
+        const csrfToken = !this.isServerMode() ? getCsrfToken() : null;
         await this.http.post(
           this.isServerMode()
             ? '/api/auth/logout?client_type=mobile'
             : '/api/auth/logout',
           undefined,
-          { credentials: 'include', skipAuthRefresh: true },
+          {
+            credentials: 'include',
+            skipAuthRefresh: true,
+            headers: csrfToken ? { 'X-CSRF-Token': csrfToken } : {},
+          },
         );
       } catch {
         // Ignore backend logout failure so local state is still cleared


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Browser logout now sends the `X-CSRF-Token` header to `/api/auth/logout`, fixing a CSRF vulnerability in `Auth.signOut()` for web clients. The header is added only in browser mode and only when a token exists (server mode unchanged); tests now cover browser-with-token, browser-without-token, and server mode, with mock cleanup via `afterEach(vi.restoreAllMocks())`.

<sup>Written for commit a61c054de58a5e997c052b2b0d1e59ef30cb8871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send X-CSRF-Token header on browser logout in `Auth.signOut`
> In browser mode, `Auth.signOut` now retrieves the CSRF token via `getCsrfToken()` and includes it as an `X-CSRF-Token` header on the `/api/auth/logout` POST request. In server mode, no CSRF header is sent. Tests cover all three cases: browser with token, server mode, and browser with null token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a61c054.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Enhanced sign-out security in browser environments by including CSRF protection via the `X-CSRF-Token` header when available, helping prevent unauthorized logout requests.
- Ensured server-mode sign-out behavior remains unchanged with CSRF header omission.
## Tests
- Added/updated automated coverage for `signOut()` to verify correct header behavior in both browser and server modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->