### PR TITLE
fix(tests): unbreak AI image integration test after dall-e-3 retirement

### DIFF
--- a/integration-tests/ai.test.ts
+++ b/integration-tests/ai.test.ts
@@ -21,7 +21,7 @@ import type { InsForgeClient } from '../src/client';
 
 const EMBEDDINGS_MODEL = 'openai/text-embedding-3-small';
 const CHAT_MODEL = 'openai/gpt-4o-mini';
-const IMAGE_MODEL = 'openai/dall-e-3';
+const IMAGE_MODEL = 'google/gemini-2.5-flash-image';
 
 /** Check if an error indicates the model is unavailable/disabled (not a real failure). */
 function isModelUnavailable(err: any): boolean {
@@ -29,6 +29,11 @@ function isModelUnavailable(err: any): boolean {
   const code = (err?.code || err?.error || '').toLowerCase();
   return (
     code === 'model_not_found' ||
+    // OpenRouter retiring a model from its catalog is upstream churn, not an
+    // SDK regression — e.g. "<id> is not a valid model ID" after dall-e-3 was
+    // removed. Surfaced by the backend as AI_UPSTREAM_UNAVAILABLE.
+    code === 'ai_upstream_unavailable' ||
+    msg.includes('not a valid model') ||
     msg.includes('not available') ||
     msg.includes('unavailable') ||
     msg.includes('disabled') ||


### PR DESCRIPTION
## What

Fixes the Integration Tests failure on `main` (every push + nightly since 2026-06-10 07:43 UTC — predates the signed-URLs merge; same failure in scheduled run 27261180383).

**Root cause:** OpenRouter retired `openai/dall-e-3` from its catalog, so `images.generate()` returns `AI_UPSTREAM_UNAVAILABLE` / "is not a valid model ID", which the test's `isModelUnavailable()` guard predates → hard fail instead of skip.

**Fix (3 lines, no tests removed):**
1. `IMAGE_MODEL` → `google/gemini-2.5-flash-image` — verified present in the live OpenRouter model list via a real project's `/api/ai/models`.
2. `isModelUnavailable()` now also matches `ai_upstream_unavailable` and "not a valid model", so future upstream catalog churn skips (per the test's own "or return structured error" intent) instead of reddening CI. Real failures (e.g. `INTERNAL_ERROR`) are still NOT swallowed — verified.

## Verification
- Replayed the exact serialized CI error against the updated guard → caught; non-model errors still propagate.
- `google/gemini-2.5-flash-image` confirmed in the live models list.
- Full authed integration run requires the CI test account secrets; will be validated by the next main/scheduled run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks CI by fixing the image generation integration test. Replaces retired `openai/dall-e-3` with `google/gemini-2.5-flash-image` and avoids hard failures when upstream models disappear.

- **Bug Fixes**
  - Set `IMAGE_MODEL` to `google/gemini-2.5-flash-image` (available in OpenRouter).
  - Expand `isModelUnavailable()` to handle `ai_upstream_unavailable` and “not a valid model” messages; real errors still fail.

<sup>Written for commit 54a5303c3662109009e2524ebb9179c7fafc331c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix AI image integration test by replacing retired dall-e-3 with gemini-2.5-flash-image
> - Updates `IMAGE_MODEL` in [ai.test.ts](https://github.com/InsForge/InsForge-sdk-js/pull/94/files#diff-5388b0d61fe8a51c6893565e9060c4decf48cf75672d499a44e7839e26840de7) from `openai/dall-e-3` to `google/gemini-2.5-flash-image` following dall-e-3 retirement.
> - Expands `isModelUnavailable` to also return `true` for error code `ai_upstream_unavailable` and messages containing `'not a valid model'`, so retired-model errors are treated as skippable rather than real test failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54a5303.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI image model for integration tests to use a different provider.
  * Enhanced error handling to better recognize and manage unavailable model scenarios during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->