### PR TITLE
INS-354 deprecate edgeFunctionToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ const admin = createAdminClient({
 
 `apiKey` belongs in `createAdminClient()`. Public and user-scoped clients use `anonKey`.
 
+### Acting as a User on the Server
+
+In edge functions or other server code that receives a user's JWT, seed the client with it via `accessToken`:
+
+```javascript
+const insforge = createClient({
+  baseUrl: "http://localhost:7130",
+  accessToken: userJwt, // e.g. from the request's Authorization header
+});
+```
+
+All requests run as that user (RLS applies). The token is used as-is — the SDK does not refresh it. `edgeFunctionToken` is a deprecated alias for this option.
+
 ### Authentication
 
 ```javascript

--- a/integration-tests/client.test.ts
+++ b/integration-tests/client.test.ts
@@ -87,7 +87,21 @@ describe('InsForgeClient', () => {
       expect(client).toBeInstanceOf(InsForgeClient);
     });
 
-    it('should set auth token when edgeFunctionToken is provided', () => {
+    it('should set auth token when accessToken is provided', () => {
+      const fakeToken = 'static-jwt-token-abc123';
+      const client = new InsForgeClient({
+        baseUrl: env.baseUrl,
+        anonKey: env.anonKey,
+        accessToken: fakeToken,
+      });
+
+      expect(client).toBeInstanceOf(InsForgeClient);
+      // The token should be set on the HTTP client
+      const headers = client.getHttpClient().getHeaders();
+      expect(headers['Authorization']).toBe(`Bearer ${fakeToken}`);
+    });
+
+    it('should still accept the deprecated edgeFunctionToken alias', () => {
       const fakeToken = 'edge-fn-jwt-token-abc123';
       const client = new InsForgeClient({
         baseUrl: env.baseUrl,
@@ -96,7 +110,6 @@ describe('InsForgeClient', () => {
       });
 
       expect(client).toBeInstanceOf(InsForgeClient);
-      // The token should be set on the HTTP client
       const headers = client.getHttpClient().getHeaders();
       expect(headers['Authorization']).toBe(`Bearer ${fakeToken}`);
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,14 +72,15 @@ export class InsForgeClient {
     this.tokenManager = new TokenManager();
     this.http = new HttpClient(config, this.tokenManager, logger);
 
-    // Check for edge function token
-    if (config.edgeFunctionToken) {
-      this.http.setAuthToken(config.edgeFunctionToken);
-      this.tokenManager.setAccessToken(config.edgeFunctionToken);
+    // edgeFunctionToken is the deprecated alias for accessToken
+    const accessToken = config.accessToken ?? config.edgeFunctionToken;
+    if (accessToken) {
+      this.http.setAuthToken(accessToken);
+      this.tokenManager.setAccessToken(accessToken);
     }
 
     this.auth = new Auth(this.http, this.tokenManager, {
-      isServerMode: config.isServerMode ?? !!config.edgeFunctionToken,
+      isServerMode: config.isServerMode ?? !!accessToken,
     });
     this.database = new Database(this.http);
     this.storage = new Storage(this.http);

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ export function createAdminClient(
 
   return new InsForgeClient({
     ...clientConfig,
-    edgeFunctionToken: apiKey,
+    accessToken: apiKey,
     isServerMode: true,
   });
 }

--- a/src/lib/__tests__/client.test.ts
+++ b/src/lib/__tests__/client.test.ts
@@ -32,6 +32,37 @@ describe('client factories', () => {
   });
 });
 
+describe('InsForgeClient – accessToken config', () => {
+  it('seeds bearer auth and implies server mode', async () => {
+    const fakeToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test';
+    const client = new InsForgeClient({
+      baseUrl: 'http://localhost:7130',
+      accessToken: fakeToken,
+    });
+
+    expect(client.getHttpClient().getHeaders().Authorization).toBe(
+      `Bearer ${fakeToken}`,
+    );
+
+    // Server path attempts a network call (no server running → error),
+    // proving accessToken implies server mode just like the deprecated alias.
+    const { error } = await client.auth.getCurrentUser();
+    expect(error).not.toBeNull();
+  });
+
+  it('takes precedence over the deprecated edgeFunctionToken alias', () => {
+    const client = new InsForgeClient({
+      baseUrl: 'http://localhost:7130',
+      accessToken: 'new-token',
+      edgeFunctionToken: 'old-token',
+    });
+
+    expect(client.getHttpClient().getHeaders().Authorization).toBe(
+      'Bearer new-token',
+    );
+  });
+});
+
 describe('InsForgeClient – edgeFunctionToken implies server mode', () => {
   it('should auto-enable server mode when edgeFunctionToken is provided', async () => {
     const fakeToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test';

--- a/src/lib/__tests__/http-client.test.ts
+++ b/src/lib/__tests__/http-client.test.ts
@@ -729,6 +729,35 @@ describe('HttpClient', () => {
       expect(tokenManager.saveSession).not.toHaveBeenCalled();
     });
 
+    it('should NOT refresh token when a static accessToken is configured even if server mode is false', async () => {
+      const tokenManager = createMockTokenManager();
+      const mockFetch = vi.fn().mockResolvedValue(
+        createJsonResponse(
+          401,
+          {
+            error: 'AUTH_UNAUTHORIZED',
+            message: 'Invalid token',
+            statusCode: 401,
+          },
+          'Unauthorized',
+        ),
+      );
+
+      const client = createClient(
+        mockFetch,
+        { accessToken: 'static-token', isServerMode: false },
+        tokenManager,
+      );
+      client.setAuthToken('static-token');
+      const error = (await client
+        .get('/api/protected')
+        .catch((e: unknown) => e)) as InsForgeError;
+
+      expect(error).toBeInstanceOf(InsForgeError);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(tokenManager.saveSession).not.toHaveBeenCalled();
+    });
+
     it('should use new access token on retry after refresh', async () => {
       const tokenManager = createMockTokenManager();
       const mockFetch = vi

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -211,6 +211,7 @@ export class HttpClient {
       statusCode === 401 &&
       REFRESHABLE_AUTH_ERROR_CODES.has(errorCode ?? '') &&
       !this.config.isServerMode &&
+      !this.config.accessToken &&
       !this.config.edgeFunctionToken &&
       !options.skipAuthRefresh &&
       authToken !== null

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -13,7 +13,10 @@ import {
 } from './cookies';
 
 export interface CreateBrowserClientOptions
-  extends Omit<InsForgeConfig, 'edgeFunctionToken' | 'isServerMode' | 'auth'>,
+  extends Omit<
+      InsForgeConfig,
+      'accessToken' | 'edgeFunctionToken' | 'isServerMode' | 'auth'
+    >,
     AuthCookieSettings {
   refreshUrl?: string;
   refreshLeewaySeconds?: number;
@@ -217,6 +220,9 @@ export function createBrowserClient(
     baseUrl,
     anonKey,
     fetch: ssrFetch,
+    // Browser clients manage tokens via the refresh route, not a static
+    // config token; shadow any untyped accessToken in the options spread.
+    accessToken: undefined,
   });
   const setAccessToken = client.setAccessToken.bind(client);
   client.setAccessToken = (token: string | null) => {

--- a/src/ssr/refresh.ts
+++ b/src/ssr/refresh.ts
@@ -15,7 +15,10 @@ import {
 } from './cookies';
 
 export interface RefreshAuthOptions
-  extends Omit<InsForgeConfig, 'edgeFunctionToken' | 'isServerMode' | 'auth'>,
+  extends Omit<
+      InsForgeConfig,
+      'accessToken' | 'edgeFunctionToken' | 'isServerMode' | 'auth'
+    >,
     AuthCookieSettings {
   request?: Request;
   cookies?: Pick<CookieStore, 'get'>;

--- a/src/ssr/server-client.ts
+++ b/src/ssr/server-client.ts
@@ -8,7 +8,10 @@ import {
 } from './cookies';
 
 export interface CreateServerClientOptions
-  extends Omit<InsForgeConfig, 'edgeFunctionToken' | 'isServerMode' | 'auth'>,
+  extends Omit<
+      InsForgeConfig,
+      'accessToken' | 'edgeFunctionToken' | 'isServerMode' | 'auth'
+    >,
     AuthCookieSettings {
   cookies?: Pick<CookieStore, 'get'>;
   accessToken?: string;
@@ -42,6 +45,9 @@ export function createServerClient(
     baseUrl,
     anonKey,
     isServerMode: true,
-    edgeFunctionToken: accessToken ?? undefined,
+    accessToken: accessToken ?? undefined,
+    // The cookie/option token is the only credential source here; shadow any
+    // untyped edgeFunctionToken smuggled through the options spread.
+    edgeFunctionToken: undefined,
   });
 }

--- a/src/ssr/update-session.ts
+++ b/src/ssr/update-session.ts
@@ -12,7 +12,10 @@ import {
 import { refreshAuth } from './refresh';
 
 export interface UpdateSessionOptions
-  extends Omit<InsForgeConfig, 'edgeFunctionToken' | 'isServerMode' | 'auth'>,
+  extends Omit<
+      InsForgeConfig,
+      'accessToken' | 'edgeFunctionToken' | 'isServerMode' | 'auth'
+    >,
     AuthCookieSettings {
   requestCookies: CookieStore;
   responseCookies: CookieStore;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,9 +21,17 @@ export interface InsForgeConfig {
   anonKey?: string;
 
   /**
-   * Edge Function Token (optional)
-   * Use this when running in edge functions/serverless with a user's JWT token
-   * This token will be used for all authenticated requests
+   * Static access token (optional)
+   * Seeds the client with a fixed bearer token used for all authenticated
+   * requests — e.g. a user JWT inside an edge function, or a server-signed
+   * JWT from an external auth provider. Disables automatic token refresh
+   * and implies server mode unless `isServerMode` is set explicitly.
+   */
+  accessToken?: string;
+
+  /**
+   * @deprecated Use `accessToken` instead. Same behavior; `accessToken`
+   * takes precedence when both are provided.
    */
   edgeFunctionToken?: string;
 
@@ -91,7 +99,7 @@ export interface InsForgeConfig {
 
 export type InsForgeAdminConfig = Omit<
   InsForgeConfig,
-  'anonKey' | 'edgeFunctionToken' | 'isServerMode'
+  'anonKey' | 'accessToken' | 'edgeFunctionToken' | 'isServerMode'
 > & {
   /**
    * Project admin API key. Keep this server-side only.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deprecates `edgeFunctionToken` in favor of `accessToken` to seed a static bearer token for server contexts; this implies server mode and skips token refresh. Updates docs, tests, and SSR clients; `createAdminClient` now uses `accessToken`. Linear: INS-354.

- **Refactors**
  - Added `accessToken` to `InsForgeConfig`; `edgeFunctionToken` kept as a deprecated alias, with `accessToken` taking precedence.
  - `HttpClient` no longer attempts refresh when `accessToken` is set, even if `isServerMode` is false.
  - `createAdminClient` passes the admin key as `accessToken`.
  - SSR: server client uses `accessToken`; browser client ignores any `accessToken` and relies on refresh flow.
  - README documents acting as a user with `accessToken`.

- **Migration**
  - Replace `edgeFunctionToken` with `accessToken` in server/edge code.
  - Do not pass `accessToken` to browser clients.
  - If both are provided, `accessToken` wins.
  - No changes needed for admin usage; existing calls continue to work.

<sup>Written for commit a8862519ddb9310079c897d506b6b2982e15f0f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deprecate `edgeFunctionToken` in favor of `accessToken` in `InsForgeClient`
> - Adds `accessToken` to `InsForgeConfig` as the canonical static token field; `edgeFunctionToken` remains as a deprecated alias with lower precedence.
> - Updates `InsForgeClient` constructor, `createAdminClient`, and `createServerClient` to seed the bearer token from `accessToken` instead of `edgeFunctionToken`.
> - Disables automatic token refresh in `HttpClient.shouldRefreshAccessToken` when `accessToken` is set, even if `isServerMode` is false.
> - Browser clients explicitly set `accessToken: undefined` to prevent static token leakage into cookie-managed flows.
> - Behavioral Change: clients constructed with `accessToken` or `edgeFunctionToken` now default to server mode unless `isServerMode` is explicitly overridden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a886251.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `accessToken` configuration option to pass static bearer tokens for server-side authentication (e.g., edge functions, server components).
  * Added documentation explaining how to create user-scoped clients with JWT tokens.

* **Deprecations**
  * `edgeFunctionToken` is now deprecated; use `accessToken` instead (still supported as an alias).

* **Improvements**
  * Token refresh is now disabled when using static `accessToken` configuration.
  * Browser and server client types updated to align token handling with their authentication models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->