### PR TITLE
[codex] Add SSR auth action helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ import { createBrowserClient } from "@insforge/sdk/ssr";
 export const insforge = createBrowserClient();
 ```
 
+`createBrowserClient()` is for Client Components that consume an existing SSR
+session. Its TypeScript surface does not include auth mutations such as
+`signInWithPassword()`, `signUp()`, or `signOut()`. Run auth mutations on the
+server so the app can write server-owned auth cookies.
+
 ```typescript
 // app/lib/insforge/server.ts
 import { cookies } from "next/headers";
@@ -383,18 +388,51 @@ import { createRefreshAuthRouter } from "@insforge/sdk/ssr";
 export const { POST } = createRefreshAuthRouter();
 ```
 
-For server-owned refresh cookies, run sign-in in a Route Handler or Server Action and use `setAuthCookies()` from `@insforge/sdk/ssr` with the framework cookie writer. In Next.js Route Handlers, pass `response.cookies`:
+For sign-in, sign-up, and sign-out, use `createAuthActions()` in a Server
+Action file. Server Actions are stable in Next.js 14+.
 
 ```typescript
-import { NextResponse } from "next/server";
-import { setAuthCookies } from "@insforge/sdk/ssr";
+// app/actions.ts
+"use server";
 
-const response = NextResponse.json({ user: data.user });
-setAuthCookies(response.cookies, {
-  accessToken: data.accessToken,
-  refreshToken: data.refreshToken,
-});
-return response;
+import { cookies } from "next/headers";
+import { createAuthActions } from "@insforge/sdk/ssr";
+
+export async function signIn(formData: FormData) {
+  const auth = createAuthActions({ cookies: await cookies() });
+
+  return auth.signInWithPassword({
+    email: String(formData.get("email")),
+    password: String(formData.get("password")),
+  });
+}
+```
+
+For Route Handlers, pass request cookies for reading the current session and
+response cookies for writing the next session:
+
+```typescript
+// app/api/auth/sign-out/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { createAuthActions } from "@insforge/sdk/ssr";
+
+export async function POST(request: NextRequest) {
+  const response = NextResponse.json({ ok: true });
+  const auth = createAuthActions({
+    requestCookies: request.cookies,
+    responseCookies: response.cookies,
+  });
+
+  const { error } = await auth.signOut();
+  if (error) {
+    return NextResponse.json(
+      { error: error.error, message: error.message },
+      { status: error.statusCode }
+    );
+  }
+
+  return response;
+}
 ```
 
 If your refresh route needs custom side effects:

--- a/README.md
+++ b/README.md
@@ -389,7 +389,9 @@ export const { POST } = createRefreshAuthRouter();
 ```
 
 For sign-in, sign-up, and sign-out, use `createAuthActions()` in a Server
-Action file. Server Actions are stable in Next.js 14+.
+Action file. Server Actions are stable in Next.js 14+. Do not return raw auth
+responses from Server Actions; return only the user or app-specific safe fields
+so access and refresh tokens stay server-owned.
 
 ```typescript
 // app/actions.ts
@@ -401,19 +403,92 @@ import { createAuthActions } from "@insforge/sdk/ssr";
 export async function signIn(formData: FormData) {
   const auth = createAuthActions({ cookies: await cookies() });
 
-  return auth.signInWithPassword({
+  const { data, error } = await auth.signInWithPassword({
     email: String(formData.get("email")),
     password: String(formData.get("password")),
   });
+
+  return { user: data?.user ?? null, error };
 }
 ```
+
+For OAuth in SSR apps, start and finish the flow on the server. Store the PKCE
+verifier in an httpOnly app cookie and exchange the callback code with
+`createAuthActions()`:
+
+```typescript
+// app/actions.ts
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { createAuthActions } from "@insforge/sdk/ssr";
+
+export async function signInWithGoogle() {
+  const cookieStore = await cookies();
+  const auth = createAuthActions({ cookies: cookieStore });
+  const { data, error } = await auth.signInWithOAuth("google", {
+    redirectTo: new URL(
+      "/api/auth/callback",
+      process.env.NEXT_PUBLIC_APP_URL
+    ).toString(),
+    skipBrowserRedirect: true,
+  });
+
+  if (error || !data.url || !data.codeVerifier) {
+    throw new Error(error?.message ?? "OAuth init failed");
+  }
+
+  cookieStore.set("insforge_code_verifier", data.codeVerifier, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 600,
+  });
+
+  redirect(data.url);
+}
+```
+
+```typescript
+// app/api/auth/callback/route.ts
+import { cookies } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+import { createAuthActions } from "@insforge/sdk/ssr";
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("insforge_code");
+  const verifier = (await cookies()).get("insforge_code_verifier")?.value;
+  if (!code || !verifier) {
+    return NextResponse.redirect(new URL("/login?error=oauth", request.url));
+  }
+
+  const response = NextResponse.redirect(new URL("/dashboard", request.url));
+  const auth = createAuthActions({
+    requestCookies: request.cookies,
+    responseCookies: response.cookies,
+  });
+  const { error } = await auth.exchangeOAuthCode(code, verifier);
+  if (error) {
+    return NextResponse.redirect(new URL("/login?error=oauth", request.url));
+  }
+
+  response.cookies.delete("insforge_code_verifier");
+  return response;
+}
+```
+
+SSR browser clients do not exchange OAuth callbacks automatically. OAuth
+callbacks must be completed on the server so the refresh token lands in the
+httpOnly app cookie.
 
 For Route Handlers, pass request cookies for reading the current session and
 response cookies for writing the next session:
 
 ```typescript
 // app/api/auth/sign-out/route.ts
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { createAuthActions } from "@insforge/sdk/ssr";
 
 export async function POST(request: NextRequest) {

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -86,7 +86,9 @@ export const { POST } = createRefreshAuthRouter();
 ```
 
 For server-owned refresh cookies, sign-in, sign-up, and sign-out should run
-through a Server Action or Route Handler that can set cookies.
+through a Server Action or Route Handler that can set cookies. Do not return
+raw auth responses from Server Actions; return only the user or app-specific
+safe fields.
 
 ```typescript
 // app/actions.ts
@@ -98,15 +100,24 @@ import { createAuthActions } from "@insforge/sdk/ssr";
 export async function signIn(formData: FormData) {
   const auth = createAuthActions({ cookies: await cookies() });
 
-  return auth.signInWithPassword({
+  const { data, error } = await auth.signInWithPassword({
     email: String(formData.get("email")),
     password: String(formData.get("password")),
   });
+
+  return { user: data?.user ?? null, error };
 }
 ```
 
 In Route Handlers, pass `requestCookies` and `responseCookies` to the same
 helper when request and response cookie stores are separate.
+
+For OAuth, initiate and exchange on the server. Use
+`createAuthActions().signInWithOAuth(provider, { redirectTo, skipBrowserRedirect: true })`
+in a Server Action, store the returned `codeVerifier` in an httpOnly app cookie,
+redirect to `data.url`, then call `createAuthActions().exchangeOAuthCode(code,
+codeVerifier)` from the callback Route Handler. SSR browser clients do not
+auto-exchange OAuth callbacks.
 
 Use `refreshAuth()` directly when the route needs app-specific logic:
 

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -59,6 +59,10 @@ const insforge = createBrowserClient({
 
 The browser client reads the access-token cookie, uses it for Database, Storage, Functions, and Realtime, and calls the refresh route when the access token is missing or near expiry.
 
+The browser client consumes an existing SSR session. Its TypeScript surface does
+not include auth mutations such as `signInWithPassword()`, `signUp()`, or
+`signOut()`.
+
 ### `createServerClient()`
 
 ```typescript
@@ -81,33 +85,28 @@ import { createRefreshAuthRouter } from "@insforge/sdk/ssr";
 export const { POST } = createRefreshAuthRouter();
 ```
 
-For server-owned refresh cookies, sign-in should also run through a Route Handler or Server Action that can set cookies:
+For server-owned refresh cookies, sign-in, sign-up, and sign-out should run
+through a Server Action or Route Handler that can set cookies.
 
 ```typescript
-import { NextResponse } from "next/server";
-import { createServerClient, setAuthCookies } from "@insforge/sdk/ssr";
+// app/actions.ts
+"use server";
 
-export async function POST(request: Request) {
-  const client = createServerClient();
-  const { data, error } = await client.auth.signInWithPassword(
-    await request.json(),
-  );
-  if (error || !data?.accessToken) {
-    return Response.json(error, { status: error?.statusCode ?? 400 });
-  }
+import { cookies } from "next/headers";
+import { createAuthActions } from "@insforge/sdk/ssr";
 
-  const response = NextResponse.json({
-    accessToken: data.accessToken,
-    user: data.user,
+export async function signIn(formData: FormData) {
+  const auth = createAuthActions({ cookies: await cookies() });
+
+  return auth.signInWithPassword({
+    email: String(formData.get("email")),
+    password: String(formData.get("password")),
   });
-  setAuthCookies(response.cookies, {
-    accessToken: data.accessToken,
-    refreshToken: data.refreshToken,
-  });
-
-  return response;
 }
 ```
+
+In Route Handlers, pass `requestCookies` and `responseCookies` to the same
+helper when request and response cookie stores are separate.
 
 Use `refreshAuth()` directly when the route needs app-specific logic:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -81,6 +81,7 @@ export class InsForgeClient {
 
     this.auth = new Auth(this.http, this.tokenManager, {
       isServerMode: config.isServerMode ?? !!accessToken,
+      detectOAuthCallback: config.auth?.detectOAuthCallback,
     });
     this.database = new Database(this.http);
     this.storage = new Storage(this.http);

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -45,6 +45,7 @@ import { ERROR_CODES, oAuthProvidersSchema } from '@insforge/shared-schemas';
 
 interface AuthOptions {
   isServerMode?: boolean;
+  detectOAuthCallback?: boolean;
 }
 
 type OAuthSignInOptions = {
@@ -65,7 +66,10 @@ export class Auth {
     private tokenManager: TokenManager,
     private options: AuthOptions = {},
   ) {
-    this.authCallbackHandled = this.detectAuthCallback();
+    this.authCallbackHandled =
+      options.detectOAuthCallback === false
+        ? Promise.resolve()
+        : this.detectAuthCallback();
   }
 
   private isServerMode(): boolean {

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -293,7 +293,7 @@ export class Auth {
       const { provider } = signInOptions;
       const providerKey = encodeURIComponent(provider.toLowerCase());
 
-      const codeVerifier = generateCodeVerifier();
+      const codeVerifier = await generateCodeVerifier();
       const codeChallenge = await generateCodeChallenge(codeVerifier);
       storePkceVerifier(codeVerifier);
 

--- a/src/modules/auth/helpers.ts
+++ b/src/modules/auth/helpers.ts
@@ -10,6 +10,25 @@ import { InsForgeError } from '../../types';
 
 const PKCE_VERIFIER_KEY = 'insforge_pkce_verifier';
 
+type WebCrypto = Pick<Crypto, 'getRandomValues' | 'subtle'>;
+
+async function getWebCrypto(): Promise<WebCrypto> {
+  const webCrypto = (globalThis as typeof globalThis & {
+    crypto?: Partial<WebCrypto>;
+  }).crypto;
+
+  if (typeof webCrypto?.getRandomValues === 'function' && webCrypto.subtle) {
+    return webCrypto as WebCrypto;
+  }
+
+  if (typeof process !== 'undefined' && process.versions?.node) {
+    const { webcrypto } = await import('node:crypto');
+    return webcrypto as unknown as WebCrypto;
+  }
+
+  throw new Error('Web Crypto API is not available in this environment');
+}
+
 /**
  * Base64 URL encode without padding (per RFC 7636)
  */
@@ -24,9 +43,10 @@ function base64UrlEncode(buffer: Uint8Array): string {
 /**
  * Generate a cryptographically random code verifier for PKCE
  */
-export function generateCodeVerifier(): string {
+export async function generateCodeVerifier(): Promise<string> {
+  const webCrypto = await getWebCrypto();
   const array = new Uint8Array(32);
-  crypto.getRandomValues(array);
+  webCrypto.getRandomValues(array);
   return base64UrlEncode(array);
 }
 
@@ -34,9 +54,10 @@ export function generateCodeVerifier(): string {
  * Generate code challenge from verifier using SHA-256 (S256 method)
  */
 export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const webCrypto = await getWebCrypto();
   const encoder = new TextEncoder();
   const data = encoder.encode(verifier);
-  const hash = await crypto.subtle.digest('SHA-256', data);
+  const hash = await webCrypto.subtle.digest('SHA-256', data);
   return base64UrlEncode(new Uint8Array(hash));
 }
 

--- a/src/ssr.ts
+++ b/src/ssr.ts
@@ -14,6 +14,11 @@ export {
   type RefreshAuthRouteHandler,
 } from './ssr/refresh';
 export {
+  createAuthActions,
+  type AuthActions,
+  type CreateAuthActionsOptions,
+} from './ssr/auth-actions';
+export {
   updateSession,
   type UpdateSessionOptions,
   type UpdateSessionResult,

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -372,9 +372,194 @@ describe('@insforge/sdk/ssr auth actions', () => {
     });
 
     expect(result.error).toBeNull();
+    expect(result.data).toEqual({ user: { id: 'user-1' } });
+    expect('accessToken' in result.data!).toBe(false);
+    expect('refreshToken' in result.data!).toBe(false);
     expect(cookies.values.get('insforge_access_token')).toBe(accessToken);
     expect(cookies.values.get('insforge_refresh_token')).toBe(refreshToken);
     expect(cookies.options.get('insforge_refresh_token')?.httpOnly).toBe(true);
+  });
+
+  it('does not write cookies or return tokens when sign-up requires verification', async () => {
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe(
+        'https://api.insforge.test/api/auth/users?client_type=mobile',
+      );
+      expect(JSON.parse(String(init.body))).toEqual({
+        email: 'new@example.com',
+        password: 'secret',
+      });
+      return jsonResponse(200, {
+        accessToken: null,
+        requireEmailVerification: true,
+      });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.signUp({
+      email: 'new@example.com',
+      password: 'secret',
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ requireEmailVerification: true });
+    expect(cookies.set).not.toHaveBeenCalled();
+  });
+
+  it('signs in with an ID token and returns sanitized data', async () => {
+    const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    const refreshToken = jwtWithExp(Math.floor(Date.now() / 1000) + 86400);
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://api.insforge.test/api/auth/id-token?client_type=mobile');
+      expect(JSON.parse(String(init.body))).toEqual({
+        provider: 'google',
+        token: 'id-token',
+      });
+      return jsonResponse(200, {
+        accessToken,
+        refreshToken,
+        csrfToken: 'csrf-token',
+        user: { id: 'user-1' },
+      });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.signInWithIdToken({
+      provider: 'google',
+      token: 'id-token',
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ user: { id: 'user-1' } });
+    expect('accessToken' in result.data!).toBe(false);
+    expect('refreshToken' in result.data!).toBe(false);
+    expect('csrfToken' in result.data!).toBe(false);
+    expect(cookies.values.get('insforge_refresh_token')).toBe(refreshToken);
+  });
+
+  it('starts OAuth through server mode without writing session cookies', async () => {
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string) => {
+      const oauthUrl = new URL(url);
+      expect(oauthUrl.origin + oauthUrl.pathname).toBe(
+        'https://api.insforge.test/api/auth/oauth/google',
+      );
+      expect(oauthUrl.searchParams.get('redirect_uri')).toBe(
+        'https://app.test/api/auth/callback',
+      );
+      expect(oauthUrl.searchParams.get('code_challenge')).toBeTruthy();
+      return jsonResponse(200, {
+        authUrl: 'https://accounts.example/oauth',
+      });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.signInWithOAuth('google', {
+      redirectTo: 'https://app.test/api/auth/callback',
+      skipBrowserRedirect: true,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data.url).toBe('https://accounts.example/oauth');
+    expect(result.data.codeVerifier).toBeTruthy();
+    expect(cookies.set).not.toHaveBeenCalled();
+  });
+
+  it('exchanges OAuth codes and returns sanitized data', async () => {
+    const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    const refreshToken = jwtWithExp(Math.floor(Date.now() / 1000) + 86400);
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe(
+        'https://api.insforge.test/api/auth/oauth/exchange?client_type=mobile',
+      );
+      expect(JSON.parse(String(init.body))).toEqual({
+        code: 'oauth-code',
+        code_verifier: 'code-verifier',
+      });
+      return jsonResponse(200, {
+        accessToken,
+        refreshToken,
+        user: { id: 'user-1' },
+      });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.exchangeOAuthCode('oauth-code', 'code-verifier');
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ user: { id: 'user-1' } });
+    expect('accessToken' in result.data!).toBe(false);
+    expect(cookies.values.get('insforge_access_token')).toBe(accessToken);
+    expect(cookies.values.get('insforge_refresh_token')).toBe(refreshToken);
+  });
+
+  it('verifies email and returns sanitized data', async () => {
+    const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    const refreshToken = jwtWithExp(Math.floor(Date.now() / 1000) + 86400);
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe(
+        'https://api.insforge.test/api/auth/email/verify?client_type=mobile',
+      );
+      expect(JSON.parse(String(init.body))).toEqual({
+        email: 'user@example.com',
+        otp: '123456',
+      });
+      return jsonResponse(200, {
+        accessToken,
+        refreshToken,
+        user: { id: 'user-1' },
+      });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.verifyEmail({
+      email: 'user@example.com',
+      otp: '123456',
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ user: { id: 'user-1' } });
+    expect('refreshToken' in result.data!).toBe(false);
+    expect(cookies.values.get('insforge_refresh_token')).toBe(refreshToken);
+  });
+
+  it('throws when auth actions cannot resolve a writable cookie store', () => {
+    expect(() =>
+      createAuthActions({
+        baseUrl: 'https://api.insforge.test',
+        anonKey: 'anon-key',
+        fetch: vi.fn() as any,
+      }),
+    ).toThrow('requires a writable cookie store');
   });
 
   it('supports split request and response cookies for route handlers', async () => {

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -3,6 +3,7 @@ import { ERROR_CODES } from '@insforge/shared-schemas';
 import {
   accessTokenCookieOptions,
   clearAuthCookies,
+  createAuthActions,
   createBrowserClient,
   createRefreshAuthRouter,
   createServerClient,
@@ -300,6 +301,114 @@ describe('@insforge/sdk/ssr cookies', () => {
 
     expect(response.status).toBe(401);
     expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('does not exchange OAuth callbacks during SSR browser client initialization', async () => {
+    const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    vi.stubGlobal('document', {
+      cookie: `insforge_access_token=${encodeURIComponent(accessToken)}`,
+      title: 'App',
+    });
+    vi.stubGlobal('window', {
+      location: {
+        search: '?insforge_code=oauth-code',
+        href: 'https://app.test/callback?insforge_code=oauth-code',
+      },
+      history: {
+        replaceState: vi.fn(),
+      },
+    });
+    vi.stubGlobal('sessionStorage', {
+      getItem: vi.fn(() => 'code-verifier'),
+      removeItem: vi.fn(),
+    });
+    const fetch = vi.fn(async () => jsonResponse(200, { ok: true }));
+
+    createBrowserClient({
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    await Promise.resolve();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('@insforge/sdk/ssr auth actions', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('signs in with password through the mobile flow and writes auth cookies', async () => {
+    const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    const refreshToken = jwtWithExp(Math.floor(Date.now() / 1000) + 86400);
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe(
+        'https://api.insforge.test/api/auth/sessions?client_type=mobile',
+      );
+      expect(JSON.parse(String(init.body))).toEqual({
+        email: 'user@example.com',
+        password: 'secret',
+      });
+      return jsonResponse(200, {
+        accessToken,
+        refreshToken,
+        user: { id: 'user-1' },
+      });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.signInWithPassword({
+      email: 'user@example.com',
+      password: 'secret',
+    });
+
+    expect(result.error).toBeNull();
+    expect(cookies.values.get('insforge_access_token')).toBe(accessToken);
+    expect(cookies.values.get('insforge_refresh_token')).toBe(refreshToken);
+    expect(cookies.options.get('insforge_refresh_token')?.httpOnly).toBe(true);
+  });
+
+  it('supports split request and response cookies for route handlers', async () => {
+    const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    const requestCookies = cookieStore({
+      insforge_access_token: accessToken,
+      insforge_refresh_token: 'old-refresh',
+    });
+    const responseCookies = cookieStore();
+    const fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(new Headers(init.headers).get('Authorization')).toBe(
+        `Bearer ${accessToken}`,
+      );
+      return new Response(null, { status: 204 });
+    });
+
+    const auth = createAuthActions({
+      requestCookies,
+      responseCookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.signOut();
+
+    expect(result.error).toBeNull();
+    expect(responseCookies.values.get('insforge_access_token')).toBe('');
+    expect(responseCookies.values.get('insforge_refresh_token')).toBe('');
+    expect(responseCookies.options.get('insforge_refresh_token')?.maxAge).toBe(
+      0,
+    );
+    expect(requestCookies.values.get('insforge_refresh_token')).toBe(
+      'old-refresh',
+    );
   });
 });
 

--- a/src/ssr/auth-actions.ts
+++ b/src/ssr/auth-actions.ts
@@ -1,0 +1,128 @@
+import { InsForgeClient } from '../client';
+import type { InsForgeConfig } from '../types';
+import { createServerClient } from './server-client';
+import {
+  clearAuthCookies,
+  setAuthCookies,
+  type AuthCookieSettings,
+  type CookieStore,
+  type CookieWriter,
+} from './cookies';
+
+export interface CreateAuthActionsOptions
+  extends Omit<
+      InsForgeConfig,
+      'accessToken' | 'edgeFunctionToken' | 'isServerMode' | 'auth'
+    >,
+    AuthCookieSettings {
+  /**
+   * Read/write cookie store. Use this in Next.js Server Actions:
+   * `createAuthActions({ cookies: await cookies() })`.
+   */
+  cookies?: CookieStore;
+
+  /**
+   * Request cookie reader. Use with `responseCookies` in Route Handlers where
+   * request and response cookies are separate objects.
+   */
+  requestCookies?: Pick<CookieStore, 'get'>;
+
+  /**
+   * Response cookie writer. Use with `requestCookies` in Route Handlers.
+   */
+  responseCookies?: CookieWriter;
+}
+
+export interface AuthActions {
+  signUp: InsForgeClient['auth']['signUp'];
+  signInWithPassword: InsForgeClient['auth']['signInWithPassword'];
+  signInWithIdToken: InsForgeClient['auth']['signInWithIdToken'];
+  exchangeOAuthCode: InsForgeClient['auth']['exchangeOAuthCode'];
+  verifyEmail: InsForgeClient['auth']['verifyEmail'];
+  signOut: InsForgeClient['auth']['signOut'];
+}
+
+function persistSessionCookies(
+  cookies: CookieWriter | undefined,
+  data: { accessToken?: string | null; refreshToken?: string | null } | null,
+  settings: AuthCookieSettings,
+): void {
+  if (!data?.accessToken) return;
+
+  setAuthCookies(
+    cookies,
+    {
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+    },
+    settings,
+  );
+}
+
+export function createAuthActions(
+  options: CreateAuthActionsOptions = {},
+): AuthActions {
+  const {
+    cookies,
+    requestCookies,
+    responseCookies,
+    names,
+    options: cookieOptions,
+    ...clientOptions
+  } = options;
+  const readCookies = requestCookies ?? cookies;
+  const writeCookies = responseCookies ?? cookies;
+  const cookieSettings: AuthCookieSettings = {
+    names,
+    options: cookieOptions,
+  };
+
+  const createClient = () =>
+    createServerClient({
+      ...clientOptions,
+      names,
+      options: cookieOptions,
+      cookies: readCookies,
+    });
+
+  return {
+    signUp: async (request) => {
+      const result = await createClient().auth.signUp(request);
+      persistSessionCookies(writeCookies, result.data, cookieSettings);
+      return result;
+    },
+
+    signInWithPassword: async (request) => {
+      const result = await createClient().auth.signInWithPassword(request);
+      persistSessionCookies(writeCookies, result.data, cookieSettings);
+      return result;
+    },
+
+    signInWithIdToken: async (credentials) => {
+      const result = await createClient().auth.signInWithIdToken(credentials);
+      persistSessionCookies(writeCookies, result.data, cookieSettings);
+      return result;
+    },
+
+    exchangeOAuthCode: async (code, codeVerifier) => {
+      const result = await createClient().auth.exchangeOAuthCode(
+        code,
+        codeVerifier,
+      );
+      persistSessionCookies(writeCookies, result.data, cookieSettings);
+      return result;
+    },
+
+    verifyEmail: async (request) => {
+      const result = await createClient().auth.verifyEmail(request);
+      persistSessionCookies(writeCookies, result.data, cookieSettings);
+      return result;
+    },
+
+    signOut: async () => {
+      const result = await createClient().auth.signOut();
+      clearAuthCookies(writeCookies, cookieSettings);
+      return result;
+    },
+  };
+}

--- a/src/ssr/auth-actions.ts
+++ b/src/ssr/auth-actions.ts
@@ -1,5 +1,5 @@
 import { InsForgeClient } from '../client';
-import type { InsForgeConfig } from '../types';
+import type { InsForgeConfig, InsForgeError } from '../types';
 import { createServerClient } from './server-client';
 import {
   clearAuthCookies,
@@ -33,12 +33,26 @@ export interface CreateAuthActionsOptions
   responseCookies?: CookieWriter;
 }
 
+type AuthTokenKeys = 'accessToken' | 'refreshToken' | 'csrfToken';
+type SafeAuthData<T> = Omit<NonNullable<T>, AuthTokenKeys>;
+type AuthResultData<TMethod extends (...args: any[]) => Promise<any>> =
+  Awaited<ReturnType<TMethod>> extends { data: infer TData } ? TData : never;
+type SafeAuthAction<TMethod extends (...args: any[]) => Promise<any>> = (
+  ...args: Parameters<TMethod>
+) => Promise<{
+  data: SafeAuthData<AuthResultData<TMethod>> | null;
+  error: InsForgeError | null;
+}>;
+
 export interface AuthActions {
-  signUp: InsForgeClient['auth']['signUp'];
-  signInWithPassword: InsForgeClient['auth']['signInWithPassword'];
-  signInWithIdToken: InsForgeClient['auth']['signInWithIdToken'];
-  exchangeOAuthCode: InsForgeClient['auth']['exchangeOAuthCode'];
-  verifyEmail: InsForgeClient['auth']['verifyEmail'];
+  signUp: SafeAuthAction<InsForgeClient['auth']['signUp']>;
+  signInWithPassword: SafeAuthAction<
+    InsForgeClient['auth']['signInWithPassword']
+  >;
+  signInWithOAuth: InsForgeClient['auth']['signInWithOAuth'];
+  signInWithIdToken: SafeAuthAction<InsForgeClient['auth']['signInWithIdToken']>;
+  exchangeOAuthCode: SafeAuthAction<InsForgeClient['auth']['exchangeOAuthCode']>;
+  verifyEmail: SafeAuthAction<InsForgeClient['auth']['verifyEmail']>;
   signOut: InsForgeClient['auth']['signOut'];
 }
 
@@ -59,6 +73,30 @@ function persistSessionCookies(
   );
 }
 
+function sanitizeAuthData<T>(
+  data: T | null,
+): SafeAuthData<T> | null {
+  if (!data) return null;
+
+  const {
+    accessToken: _accessToken,
+    refreshToken: _refreshToken,
+    csrfToken: _csrfToken,
+    ...safeData
+  } = data as Record<string, unknown>;
+
+  return safeData as SafeAuthData<T>;
+}
+
+function toSafeAuthResult<TMethod extends (...args: any[]) => Promise<any>>(
+  result: Awaited<ReturnType<TMethod>>,
+): Awaited<ReturnType<SafeAuthAction<TMethod>>> {
+  return {
+    data: sanitizeAuthData(result.data),
+    error: result.error,
+  };
+}
+
 export function createAuthActions(
   options: CreateAuthActionsOptions = {},
 ): AuthActions {
@@ -72,6 +110,12 @@ export function createAuthActions(
   } = options;
   const readCookies = requestCookies ?? cookies;
   const writeCookies = responseCookies ?? cookies;
+  if (!writeCookies?.set) {
+    throw new Error(
+      'createAuthActions() requires a writable cookie store. Pass cookies in Server Actions or responseCookies in Route Handlers.',
+    );
+  }
+
   const cookieSettings: AuthCookieSettings = {
     names,
     options: cookieOptions,
@@ -89,19 +133,30 @@ export function createAuthActions(
     signUp: async (request) => {
       const result = await createClient().auth.signUp(request);
       persistSessionCookies(writeCookies, result.data, cookieSettings);
-      return result;
+      return toSafeAuthResult<InsForgeClient['auth']['signUp']>(result);
     },
 
     signInWithPassword: async (request) => {
       const result = await createClient().auth.signInWithPassword(request);
       persistSessionCookies(writeCookies, result.data, cookieSettings);
-      return result;
+      return toSafeAuthResult<InsForgeClient['auth']['signInWithPassword']>(
+        result,
+      );
+    },
+
+    signInWithOAuth: async (providerOrOptions: any, signInOptions?: any) => {
+      return createClient().auth.signInWithOAuth(
+        providerOrOptions,
+        signInOptions,
+      );
     },
 
     signInWithIdToken: async (credentials) => {
       const result = await createClient().auth.signInWithIdToken(credentials);
       persistSessionCookies(writeCookies, result.data, cookieSettings);
-      return result;
+      return toSafeAuthResult<InsForgeClient['auth']['signInWithIdToken']>(
+        result,
+      );
     },
 
     exchangeOAuthCode: async (code, codeVerifier) => {
@@ -110,13 +165,15 @@ export function createAuthActions(
         codeVerifier,
       );
       persistSessionCookies(writeCookies, result.data, cookieSettings);
-      return result;
+      return toSafeAuthResult<InsForgeClient['auth']['exchangeOAuthCode']>(
+        result,
+      );
     },
 
     verifyEmail: async (request) => {
       const result = await createClient().auth.verifyEmail(request);
       persistSessionCookies(writeCookies, result.data, cookieSettings);
-      return result;
+      return toSafeAuthResult<InsForgeClient['auth']['verifyEmail']>(result);
     },
 
     signOut: async () => {

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -12,6 +12,15 @@ import {
   type AuthCookieSettings,
 } from './cookies';
 
+type BrowserAuth = Pick<
+  InsForgeClient['auth'],
+  'getCurrentUser' | 'getProfile' | 'getPublicAuthConfig'
+>;
+
+export type BrowserInsForgeClient = Omit<InsForgeClient, 'auth'> & {
+  readonly auth: BrowserAuth;
+};
+
 export interface CreateBrowserClientOptions
   extends Omit<
       InsForgeConfig,
@@ -101,7 +110,7 @@ function getRequestUrl(input: RequestInfo | URL): string {
 
 export function createBrowserClient(
   options: CreateBrowserClientOptions = {},
-): InsForgeClient {
+): BrowserInsForgeClient {
   let { baseUrl, anonKey } = options;
   try {
     baseUrl ||= process.env.NEXT_PUBLIC_INSFORGE_URL;
@@ -223,6 +232,9 @@ export function createBrowserClient(
     // Browser clients manage tokens via the refresh route, not a static
     // config token; shadow any untyped accessToken in the options spread.
     accessToken: undefined,
+    auth: {
+      detectOAuthCallback: false,
+    },
   });
   const setAccessToken = client.setAccessToken.bind(client);
   client.setAccessToken = (token: string | null) => {
@@ -241,5 +253,5 @@ export function createBrowserClient(
     void refreshFromRoute().catch(() => undefined);
   }
 
-  return client;
+  return client as unknown as BrowserInsForgeClient;
 }

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -253,5 +253,7 @@ export function createBrowserClient(
     void refreshFromRoute().catch(() => undefined);
   }
 
+  // Runtime still returns the normal client object; SSR auth mutation guardrails
+  // are enforced by the public TypeScript surface.
   return client as unknown as BrowserInsForgeClient;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,19 @@ export interface InsForgeConfig {
   isServerMode?: boolean;
 
   /**
+   * Advanced auth module options.
+   */
+  auth?: {
+    /**
+     * Detect and exchange OAuth callback parameters on browser client
+     * initialization. SSR browser clients disable this so auth mutations can
+     * stay server-owned.
+     * @default true
+     */
+    detectOAuthCallback?: boolean;
+  };
+
+  /**
    * Custom headers to include with every request
    */
   headers?: Record<string, string>;


### PR DESCRIPTION
## Summary
- narrow createBrowserClient's SSR auth type so browser clients only expose read-only auth methods
- add createAuthActions() for server-owned sign up/sign in/sign out cookie flows
- document Server Action and Route Handler usage while keeping refresh on createRefreshAuthRouter()

## Validation
- npm run typecheck
- ./node_modules/.bin/vitest run src
- npm run build

## Notes
- npm run lint currently cannot run because this repository has no ESLint configuration file; ESLint exits before checking source files.
- A full ./node_modules/.bin/vitest run also scans .claude/worktrees integration tests and fails without INSFORGE_INTEGRATION_* env vars, so validation used the current src test scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side auth action helpers for SSR with secure cookie writes and token-safe returns, and narrows the SSR browser client to a read-only auth surface that doesn’t auto-exchange OAuth callbacks. Also fixes PKCE generation to work on Node 18.

- **New Features**
  - Added `createAuthActions()` in `@insforge/sdk/ssr` for Server Actions and Route Handlers; writes/clears cookies for `signUp`, `signInWithPassword`, `signInWithIdToken`, `exchangeOAuthCode`, `verifyEmail`, and `signOut`; returns data with tokens redacted; throws if no writable cookie store; supports split `requestCookies`/`responseCookies`; `signInWithOAuth` returns `{ url, codeVerifier }` and does not write cookies.
  - `createBrowserClient()` now returns a read-only `auth` surface (`getCurrentUser`, `getProfile`, `getPublicAuthConfig`) and disables OAuth callback detection by default; opt in via `InsForgeConfig.auth.detectOAuthCallback`.
  - PKCE generation now uses Web Crypto in browser and `node:crypto` in Node to support Node 18.

- **Migration**
  - Move all auth mutations to a Server Action using `createAuthActions({ cookies: await cookies() })`; in Route Handlers, pass `requestCookies` and `responseCookies`.
  - For OAuth, initiate on the server with `signInWithOAuth(..., { skipBrowserRedirect: true })`, save the returned `codeVerifier` in an httpOnly app cookie, then call `exchangeOAuthCode(code, codeVerifier)` in the callback handler.

<sup>Written for commit 47771f96bb75a269361e9ce51311674979521bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `createAuthActions` SSR helper for server-side sign-in, sign-up, and sign-out
> - Introduces [`createAuthActions`](https://github.com/InsForge/InsForge-sdk-js/pull/97/files#diff-15da7fcfe2644e028f021f1648b24fba1765a10a0448009d56aa1dc195080f5b) in the SSR entrypoint, exposing `signUp`, `signInWithPassword`, `signInWithIdToken`, `exchangeOAuthCode`, `verifyEmail`, and `signOut` methods that automatically read request cookies and write updated auth cookies to the response.
> - Adds `detectOAuthCallback` config option to `InsForgeConfig` and `AuthOptions`, allowing OAuth callback detection to be skipped at init time.
> - Updates [`createBrowserClient`](https://github.com/InsForge/InsForge-sdk-js/pull/97/files#diff-a4924bb4733c98f5dde2aa08bcaadfaf2cd62d00fe300e2a198b2e5346a07fa8) to disable OAuth callback detection on init and narrows its TypeScript return type to a read-only `BrowserInsForgeClient` that omits auth mutation methods.
> - Documents the distinction between `createBrowserClient` (read-only SSR session consumption) and `createAuthActions` (server-side auth mutations) in README and SDK reference.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #97 opened
>
> - Modified `createAuthActions` factory to return sanitized authentication data by removing `accessToken`, `refreshToken`, and `csrfToken` fields from responses of `signUp`, `signInWithPassword`, `signInWithIdToken`, `exchangeOAuthCode`, and `verifyEmail` methods while preserving server-side cookie writes, and added `signInWithOAuth` method that delegates to the client without writing cookies during OAuth initiation [25fbf27]
> - Added validation in `createAuthActions` factory to throw an explicit error when neither `cookies` nor `responseCookies` provides a `.set` method, preventing runtime failures when no writable cookie store is available [25fbf27]
> - Expanded README.md and SDK-REFERENCE.md documentation to include end-to-end SSR OAuth flow guidance with `skipBrowserRedirect`, PKCE code verifier storage in httpOnly cookies, server-side callback code exchange, and warnings against returning raw auth responses from Server Actions [25fbf27]
> - Added seven new test cases covering sanitized data returns for password sign-in, sign-up with email verification requirements, ID token sign-in, OAuth initiation without session cookies, OAuth code exchange, email verification, and cookie store validation errors [25fbf27]
> - Added clarifying comment in `createBrowserClient` function noting that the runtime returns the normal client object and SSR auth mutation guardrails are enforced at the TypeScript surface level [25fbf27]
> - Bumped package version [6d1bbbf]
> - Introduced `getWebCrypto` utility function to resolve Web Crypto API implementation across browser and Node.js environments [47771f9]
> - Converted `generateCodeVerifier` and `generateCodeChallenge` functions to async and updated to use cross-platform crypto implementation [47771f9]
> - Updated OAuth initiation method to await async PKCE verifier generation [47771f9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4d68c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Next.js/SSR authentication and OAuth guidance, including Server Actions and Route Handler examples
  * Removed outdated guidance around server-owned refresh cookies and clarified token/server ownership patterns

* **New Features**
  * Added `createAuthActions()` for secure server-side sign-in/sign-up/sign-out with cookie persistence
  * Introduced configurable OAuth callback detection and a browser client surface restricted to read-only auth methods

* **Tests**
  * Expanded coverage for SSR browser initialization and OAuth/cookie behavior across auth flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->