### PR TITLE
feat(database): custom schema selection via .schema()

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,31 @@ const { data, error } = await insforge.database
   .eq("id", postId);
 ```
 
+#### Selecting a schema
+
+Queries hit the `public` schema by default. Target a custom schema by chaining `.schema()` — the table name stays bare (it maps to PostgREST's `Accept-Profile`/`Content-Profile` header):
+
+```javascript
+const { data } = await insforge.database
+  .schema("analytics")
+  .from("events")
+  .select("*");
+
+await insforge.database.schema("analytics").rpc("rollup", { day: "2026-01-01" });
+```
+
+Or set a default schema for every query when creating the client:
+
+```javascript
+const insforge = createClient({
+  baseUrl: "...",
+  anonKey: "...",
+  db: { schema: "analytics" },
+});
+```
+
+The schema must be exposed by the backend, and access is still gated by grants + RLS like `public`. Older backends that don't expose the schema return PostgREST `PGRST106` rather than silently falling back.
+
 ### File Storage
 
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -83,7 +83,7 @@ export class InsForgeClient {
       isServerMode: config.isServerMode ?? !!accessToken,
       detectOAuthCallback: config.auth?.detectOAuthCallback,
     });
-    this.database = new Database(this.http);
+    this.database = new Database(this.http, config.db?.schema);
     this.storage = new Storage(this.http);
     this.ai = new AI(this.http);
     this.functions = new Functions(this.http, config.functionsUrl);

--- a/src/modules/__tests__/database-postgrest.test.ts
+++ b/src/modules/__tests__/database-postgrest.test.ts
@@ -15,6 +15,7 @@ function makeDatabase(
   fetchFn: ReturnType<typeof vi.fn>,
   overrides: Record<string, unknown> = {},
   accessToken: string | null = 'old-token',
+  defaultSchema?: string,
 ) {
   const tokenManager = new TokenManager();
   if (accessToken) {
@@ -34,7 +35,7 @@ function makeDatabase(
   http.setAuthToken(accessToken);
 
   return {
-    database: new Database(http),
+    database: new Database(http, defaultSchema),
     tokenManager,
   };
 }
@@ -145,6 +146,37 @@ describe('Database PostgREST auth refresh', () => {
       error: 'AUTH_UNAUTHORIZED',
     });
     expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it('sends Accept-Profile when a schema is selected on a read', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse(200, [{ id: 1 }]));
+    const { database } = makeDatabase(fetchFn);
+
+    await database.schema('analytics').from('events').select('id');
+
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe('http://localhost:7130/api/database/records/events?select=id');
+    expect(new Headers(init.headers).get('Accept-Profile')).toBe('analytics');
+  });
+
+  it('sends Content-Profile when a schema is selected on a write', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse(201, [{ id: 1 }]));
+    const { database } = makeDatabase(fetchFn);
+
+    await database.schema('analytics').from('events').insert({ name: 'signup' });
+
+    const [, init] = fetchFn.mock.calls[0];
+    expect(new Headers(init.headers).get('Content-Profile')).toBe('analytics');
+  });
+
+  it('applies a default schema from config to every query', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse(200, [{ id: 1 }]));
+    const { database } = makeDatabase(fetchFn, {}, 'old-token', 'analytics');
+
+    await database.from('events').select('id');
+
+    const [, init] = fetchFn.mock.calls[0];
+    expect(new Headers(init.headers).get('Accept-Profile')).toBe('analytics');
   });
 
   it('does not refresh database requests in server mode', async () => {

--- a/src/modules/__tests__/database-postgrest.test.ts
+++ b/src/modules/__tests__/database-postgrest.test.ts
@@ -169,6 +169,17 @@ describe('Database PostgREST auth refresh', () => {
     expect(new Headers(init.headers).get('Content-Profile')).toBe('analytics');
   });
 
+  it('sends the schema profile header for rpc calls', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse(200, [{ ok: true }]));
+    const { database } = makeDatabase(fetchFn);
+
+    await database.schema('analytics').rpc('rollup', { day: '2026-01-01' });
+
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe('http://localhost:7130/api/database/rpc/rollup');
+    expect(new Headers(init.headers).get('Content-Profile')).toBe('analytics');
+  });
+
   it('applies a default schema from config to every query', async () => {
     const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse(200, [{ id: 1 }]));
     const { database } = makeDatabase(fetchFn, {}, 'old-token', 'analytics');

--- a/src/modules/database-postgrest.ts
+++ b/src/modules/database-postgrest.ts
@@ -51,12 +51,33 @@ function createInsForgePostgrestFetch(httpClient: HttpClient): typeof fetch {
 export class Database {
   private postgrest: PostgrestClient<any, any, any>;
 
-  constructor(httpClient: HttpClient) {
-    // Create postgrest client with custom fetch
+  constructor(httpClient: HttpClient, defaultSchema?: string) {
+    // Create postgrest client with custom fetch. `schema` sets the default
+    // profile; postgrest-js attaches Accept-Profile/Content-Profile headers,
+    // which the InsForge data API resolves to the target schema.
     this.postgrest = new PostgrestClient<any, any, any>('http://dummy', {
       fetch: createInsForgePostgrestFetch(httpClient),
       headers: {},
+      ...(defaultSchema ? { schema: defaultSchema } : {}),
     });
+  }
+
+  /**
+   * Select a non-default Postgres schema for the chained query. Maps to
+   * PostgREST's `Accept-Profile` (reads) / `Content-Profile` (writes) header.
+   * The schema must be exposed by the backend.
+   *
+   * @example
+   * const { data } = await client.database
+   *   .schema('analytics')
+   *   .from('events')
+   *   .select('*');
+   *
+   * @example
+   * await client.database.schema('analytics').rpc('rollup', { day: '2026-01-01' });
+   */
+  schema(schemaName: string) {
+    return this.postgrest.schema(schemaName);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,19 @@ export interface InsForgeConfig {
   };
 
   /**
+   * Database module options.
+   */
+  db?: {
+    /**
+     * Default Postgres schema for database queries. Maps to PostgREST's
+     * `Accept-Profile`/`Content-Profile` headers. Override per-query with
+     * `client.database.schema('other')`.
+     * @default "public"
+     */
+    schema?: string;
+  };
+
+  /**
    * Custom headers to include with every request
    */
   headers?: Record<string, string>;


### PR DESCRIPTION
## What

Adds PostgREST schema selection to the SDK, matching the Supabase client convention:

```js
// per-query
await client.database.schema('analytics').from('events').select('*')
await client.database.schema('analytics').rpc('rollup', { day })

// client-level default
const client = createClient({ db: { schema: 'analytics' } })
```

## How

The underlying `@supabase/postgrest-js` client already has `.schema()` — this surfaces it through the InsForge `Database` wrapper and adds a `db.schema` default on `createClient`. postgrest-js attaches `Accept-Profile` (reads) / `Content-Profile` (writes); the existing custom fetch forwards them, and the InsForge data API resolves them to the target schema.

- `src/modules/database-postgrest.ts` — `schema(name)` method + optional default schema in the constructor
- `src/types.ts` — `db?: { schema?: string }` config option
- `src/client.ts` — passes `config.db?.schema` to `Database`
- tests — `Accept-Profile` on reads, `Content-Profile` on writes, default-schema option

## Compatibility

Against a backend that doesn't expose a schema, the request fails cleanly with PostgREST `PGRST106` (406, "schema must be one of: public") — no silent fallback. Default (no `.schema()`) usage is unchanged.

Backend support: InsForge/InsForge#1585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add schema selection to the database client via `.schema()` and an optional default schema in client config. Apps can target non-public Postgres schemas on reads, writes, and RPC calls.

- **New Features**
  - `database.schema(name)` for per-query schemas; forwards `Accept-Profile` / `Content-Profile` (including RPC).
  - Default schema via `createClient({ db: { schema: 'analytics' } })`; default remains `public` if omitted.
  - Surfaces `.schema()` from `@supabase/postgrest-js` through the `Database` wrapper; tests cover reads/writes/RPC and default schema; README documents usage; requests fail clearly if the schema isn’t exposed.

- **Dependencies**
  - Bump `@insforge/sdk` version to `1.4.3`.

<sup>Written for commit 71566d9c4157991f66a3b50c0e9d5c7a63f65a2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add custom Postgres schema selection via `Database.schema()` and `config.db.schema`
> - Adds a `schema(schemaName)` method to the `Database` class in [database-postgrest.ts](https://github.com/InsForge/InsForge-sdk-js/pull/98/files#diff-4f86dc0e889d7d86ec5f647e3e90febc14f956fa0faefb6cf2e4a9f2193156b1) that delegates to `postgrest.schema()`, setting `Accept-Profile`/`Content-Profile` headers on a per-query basis.
> - Extends the `Database` constructor to accept an optional `defaultSchema`, applied globally to all queries on that instance via the `PostgrestClient` constructor.
> - Adds a `db.schema` field to `InsForgeConfig` in [types.ts](https://github.com/InsForge/InsForge-sdk-js/pull/98/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a), allowing a default schema to be passed through the top-level client config.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #98 opened
>
> - Added schema selection capability to database operations via `.schema()` method [635a590]
> - Documented schema selection feature including usage examples and backend compatibility requirements [635a590]
> - Bumped package version from 1.4.2 to 1.4.3 [71566d9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c2114d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a default database schema in configuration.
  * Added schema-scoped database queries, allowing reads and writes to target a specific schema.

* **Bug Fixes**
  * Queries now send the correct schema headers so requests are routed to the intended database schema.
  * Existing database operations now respect the configured default schema automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->