### PR TITLE
fix(realtime): preserve presence across reconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import type { InsForgeConfig } from './types';
 import { HttpClient } from './lib/http-client';
 import { Logger } from './lib/logger';
-import { TokenManager } from './lib/token-manager';
+import { AuthChangeEvent, TokenManager } from './lib/token-manager';
 import { Auth } from './modules/auth/auth';
 import { Database } from './modules/database-postgrest';
 import { Storage } from './modules/storage';
@@ -11,7 +11,8 @@ import { Realtime } from './modules/realtime';
 import { Emails } from './modules/email';
 import { Payments } from './modules/payments';
 
-export type AccessTokenChangeEvent = 'signedIn' | 'tokenRefreshed';
+export type AccessTokenChangeEvent =
+  typeof AuthChangeEvent.SIGNED_IN | typeof AuthChangeEvent.TOKEN_REFRESHED;
 
 /**
  * Main InsForge SDK Client
@@ -114,7 +115,7 @@ export class InsForgeClient {
    * client (database / storage / functions / AI / emails) and the realtime
    * token manager. Pass `null` to sign out. By default a token replacement is
    * treated as a sign-in boundary and reconnects realtime. Pass
-   * `tokenRefreshed` for a same-identity refresh to preserve a live socket; the
+   * `AuthChangeEvent.TOKEN_REFRESHED` for a same-identity refresh to preserve a live socket; the
    * refreshed token is then used at the next handshake.
    *
    * Use this when an external auth provider (Better Auth, Clerk, Auth0,
@@ -125,15 +126,20 @@ export class InsForgeClient {
    *
    * @example
    * ```typescript
+   * import { AuthChangeEvent } from '@insforge/sdk';
+   *
    * // Refresh a third-party-issued JWT periodically
    * const { token } = await fetch('/api/insforge-token').then((r) => r.json());
-   * client.setAccessToken(token, 'tokenRefreshed');
+   * client.setAccessToken(token, AuthChangeEvent.TOKEN_REFRESHED);
    *
    * // Sign-out
    * client.setAccessToken(null);
    * ```
    */
-  setAccessToken(token: string | null, event: AccessTokenChangeEvent = 'signedIn'): void {
+  setAccessToken(
+    token: string | null,
+    event: AccessTokenChangeEvent = AuthChangeEvent.SIGNED_IN
+  ): void {
     this.http.setAuthToken(token);
     if (token === null) {
       this.tokenManager.clearSession();

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,8 @@ import { Realtime } from './modules/realtime';
 import { Emails } from './modules/email';
 import { Payments } from './modules/payments';
 
+export type AccessTokenChangeEvent = 'signedIn' | 'tokenRefreshed';
+
 /**
  * Main InsForge SDK Client
  *
@@ -110,8 +112,10 @@ export class InsForgeClient {
   /**
    * Set the access token used by every SDK surface. Updates both the HTTP
    * client (database / storage / functions / AI / emails) and the realtime
-   * token manager. Pass `null` to clear. A live realtime connection remains
-   * authenticated for its lifetime; the new token is used at the next handshake.
+   * token manager. Pass `null` to sign out. By default a token replacement is
+   * treated as a sign-in boundary and reconnects realtime. Pass
+   * `tokenRefreshed` for a same-identity refresh to preserve a live socket; the
+   * refreshed token is then used at the next handshake.
    *
    * Use this when an external auth provider (Better Auth, Clerk, Auth0,
    * WorkOS, Kinde, Stytch, …) issues the JWT and you need to keep the
@@ -123,18 +127,18 @@ export class InsForgeClient {
    * ```typescript
    * // Refresh a third-party-issued JWT periodically
    * const { token } = await fetch('/api/insforge-token').then((r) => r.json());
-   * client.setAccessToken(token);
+   * client.setAccessToken(token, 'tokenRefreshed');
    *
    * // Sign-out
    * client.setAccessToken(null);
    * ```
    */
-  setAccessToken(token: string | null): void {
+  setAccessToken(token: string | null, event: AccessTokenChangeEvent = 'signedIn'): void {
     this.http.setAuthToken(token);
     if (token === null) {
       this.tokenManager.clearSession();
     } else {
-      this.tokenManager.setAccessToken(token);
+      this.tokenManager.setAccessToken(token, event);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -87,7 +87,9 @@ export class InsForgeClient {
     this.storage = new Storage(this.http);
     this.ai = new AI(this.http);
     this.functions = new Functions(this.http, config.functionsUrl);
-    this.realtime = new Realtime(this.http.baseUrl, this.tokenManager, config.anonKey);
+    this.realtime = new Realtime(this.http.baseUrl, this.tokenManager, config.anonKey, () =>
+      this.http.getValidAccessToken()
+    );
     this.emails = new Emails(this.http);
     this.payments = new Payments(this.http);
   }
@@ -108,15 +110,14 @@ export class InsForgeClient {
   /**
    * Set the access token used by every SDK surface. Updates both the HTTP
    * client (database / storage / functions / AI / emails) and the realtime
-   * token manager (which fires `onTokenChange` to reconnect the WebSocket
-   * with the new bearer). Pass `null` to clear.
+   * token manager. Pass `null` to clear. A live realtime connection remains
+   * authenticated for its lifetime; the new token is used at the next handshake.
    *
    * Use this when an external auth provider (Better Auth, Clerk, Auth0,
    * WorkOS, Kinde, Stytch, …) issues the JWT and you need to keep the
    * long-lived InsForge client in sync. Without this, you'd have to call
    * `client.getHttpClient().setAuthToken(token)` AND reach into the private
-   * `client.realtime.tokenManager.setAccessToken(token)` separately —
-   * forgetting the second one silently breaks realtime auth.
+   * realtime token manager separately.
    *
    * @example
    * ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export type {
 // Re-export utilities for advanced usage
 export { HttpClient } from './lib/http-client';
 export { TokenManager } from './lib/token-manager';
+export type { AuthChangeEvent, AuthStateChangeCallback } from './lib/token-manager';
 export { Logger } from './lib/logger';
 
 // Factory function for creating clients (Supabase-style)

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,8 @@ export type {
 
 // Re-export utilities for advanced usage
 export { HttpClient } from './lib/http-client';
-export { TokenManager } from './lib/token-manager';
-export type { AuthChangeEvent, AuthStateChangeCallback } from './lib/token-manager';
+export { AuthChangeEvent, TokenManager } from './lib/token-manager';
+export type { AuthStateChangeCallback } from './lib/token-manager';
 export { Logger } from './lib/logger';
 
 // Factory function for creating clients (Supabase-style)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
 
 // Main client
 export { InsForgeClient } from './client';
+export type { AccessTokenChangeEvent } from './client';
 
 // Types
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export type {
 
 // Re-export utilities for advanced usage
 export { HttpClient } from './lib/http-client';
-export { AuthChangeEvent, TokenManager } from './lib/token-manager';
+export { AuthChangeEvent } from './lib/token-manager';
 export type { AuthStateChangeCallback } from './lib/token-manager';
 export { Logger } from './lib/logger';
 

--- a/src/lib/__tests__/client.test.ts
+++ b/src/lib/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { InsForgeClient } from '../../client';
 import { createAdminClient } from '../../index';
 
@@ -106,43 +106,30 @@ describe('InsForgeClient – edgeFunctionToken implies server mode', () => {
 });
 
 describe('InsForgeClient.setAccessToken', () => {
-  it('fires onTokenChange on every transition (string → string → null)', () => {
+  it('notifies auth listeners on every authentication-boundary transition', () => {
     const client = new InsForgeClient({ baseUrl: 'http://localhost:7130' });
-
-    // Replace realtime's tokenManager handler with a counting probe so we can
-    // observe that the realtime path is being notified — this is what callers
-    // had to verify by hand before this method existed.
-    let count = 0;
-    // @ts-expect-error: tokenManager is private at compile-time; reaching in for the test
-    client.tokenManager.onTokenChange = () => {
-      count++;
-    };
+    const events: string[] = [];
+    client.auth.onAuthStateChange((event) => events.push(event));
 
     client.setAccessToken('token-a');
-    expect(count).toBe(1);
-
     client.setAccessToken('token-b');
-    expect(count).toBe(2);
-
     client.setAccessToken(null);
-    expect(count).toBe(3);
+    expect(events).toEqual(['signedIn', 'signedIn', 'signedOut']);
   });
 
-  it('does not fire when token is unchanged', () => {
+  it('allows each auth-state listener to unsubscribe independently', () => {
     const client = new InsForgeClient({ baseUrl: 'http://localhost:7130' });
-    let count = 0;
-    // @ts-expect-error: tokenManager is private at compile-time; reaching in for the test
-    client.tokenManager.onTokenChange = () => {
-      count++;
-    };
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubscribeFirst = client.auth.onAuthStateChange(first);
+    client.auth.onAuthStateChange(second);
 
     client.setAccessToken('same');
+    unsubscribeFirst();
     client.setAccessToken('same');
-    expect(count).toBe(1);
+    client.setAccessToken(null);
 
-    // Clearing when already null is also a no-op
-    client.setAccessToken(null);
-    client.setAccessToken(null);
-    expect(count).toBe(2);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/__tests__/client.test.ts
+++ b/src/lib/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { InsForgeClient } from '../../client';
+import * as SDK from '../../index';
 import { AuthChangeEvent, createAdminClient } from '../../index';
 
 describe('client factories', () => {
@@ -112,6 +113,10 @@ describe('InsForgeClient.setAccessToken', () => {
       SIGNED_OUT: 'signedOut',
       TOKEN_REFRESHED: 'tokenRefreshed',
     });
+  });
+
+  it('keeps TokenManager internal to the SDK package entrypoint', () => {
+    expect('TokenManager' in SDK).toBe(false);
   });
 
   it('allows callers to mark an external token replacement as a refresh', () => {

--- a/src/lib/__tests__/client.test.ts
+++ b/src/lib/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { InsForgeClient } from '../../client';
-import { createAdminClient } from '../../index';
+import { AuthChangeEvent, createAdminClient } from '../../index';
 
 describe('client factories', () => {
   it('creates an admin client with the API key as bearer auth', () => {
@@ -106,15 +106,27 @@ describe('InsForgeClient – edgeFunctionToken implies server mode', () => {
 });
 
 describe('InsForgeClient.setAccessToken', () => {
+  it('exports auth change events as runtime constants', () => {
+    expect(AuthChangeEvent).toEqual({
+      SIGNED_IN: 'signedIn',
+      SIGNED_OUT: 'signedOut',
+      TOKEN_REFRESHED: 'tokenRefreshed',
+    });
+  });
+
   it('allows callers to mark an external token replacement as a refresh', () => {
     const client = new InsForgeClient({ baseUrl: 'http://localhost:7130' });
     const events: string[] = [];
     client.auth.onAuthStateChange((event) => events.push(event));
 
     client.setAccessToken('token-a');
-    client.setAccessToken('token-b', 'tokenRefreshed');
+    client.setAccessToken('token-b', AuthChangeEvent.TOKEN_REFRESHED);
     client.setAccessToken(null);
-    expect(events).toEqual(['signedIn', 'tokenRefreshed', 'signedOut']);
+    expect(events).toEqual([
+      AuthChangeEvent.SIGNED_IN,
+      AuthChangeEvent.TOKEN_REFRESHED,
+      AuthChangeEvent.SIGNED_OUT,
+    ]);
   });
 
   it('allows each auth-state listener to unsubscribe independently', () => {

--- a/src/lib/__tests__/client.test.ts
+++ b/src/lib/__tests__/client.test.ts
@@ -106,15 +106,15 @@ describe('InsForgeClient – edgeFunctionToken implies server mode', () => {
 });
 
 describe('InsForgeClient.setAccessToken', () => {
-  it('notifies auth listeners on every authentication-boundary transition', () => {
+  it('allows callers to mark an external token replacement as a refresh', () => {
     const client = new InsForgeClient({ baseUrl: 'http://localhost:7130' });
     const events: string[] = [];
     client.auth.onAuthStateChange((event) => events.push(event));
 
     client.setAccessToken('token-a');
-    client.setAccessToken('token-b');
+    client.setAccessToken('token-b', 'tokenRefreshed');
     client.setAccessToken(null);
-    expect(events).toEqual(['signedIn', 'signedIn', 'signedOut']);
+    expect(events).toEqual(['signedIn', 'tokenRefreshed', 'signedOut']);
   });
 
   it('allows each auth-state listener to unsubscribe independently', () => {

--- a/src/lib/__tests__/http-client.test.ts
+++ b/src/lib/__tests__/http-client.test.ts
@@ -95,6 +95,25 @@ describe('HttpClient', () => {
         'tokenRefreshed'
       );
     });
+
+    it('clears an invalid browser session when the handshake refresh is rejected', async () => {
+      const tokenManager = createMockTokenManager();
+      const expiringToken = jwt(30);
+      (tokenManager.getAccessToken as ReturnType<typeof vi.fn>).mockReturnValue(expiringToken);
+      const fetchFn = vi.fn().mockResolvedValue(
+        createJsonResponse(401, {
+          error: 'AUTH_UNAUTHORIZED',
+          message: 'Refresh token is invalid',
+          statusCode: 401,
+        })
+      );
+      const client = createClient(fetchFn, {}, tokenManager);
+      client.setAuthToken(expiringToken);
+
+      await expect(client.getValidAccessToken()).rejects.toMatchObject({ statusCode: 401 });
+      expect(tokenManager.clearSession).toHaveBeenCalledOnce();
+      expect(client.getHeaders().Authorization).toBeUndefined();
+    });
   });
 
   describe('basic requests', () => {

--- a/src/lib/__tests__/http-client.test.ts
+++ b/src/lib/__tests__/http-client.test.ts
@@ -114,6 +114,36 @@ describe('HttpClient', () => {
       expect(tokenManager.clearSession).toHaveBeenCalledOnce();
       expect(client.getHeaders().Authorization).toBeUndefined();
     });
+
+    it('keeps a newer session when an earlier handshake refresh is rejected', async () => {
+      const tokenManager = createMockTokenManager();
+      const expiringToken = jwt(30);
+      (tokenManager.getAccessToken as ReturnType<typeof vi.fn>).mockReturnValue(expiringToken);
+      let resolveRefresh!: (response: Response) => void;
+      const fetchFn = vi.fn().mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+      const client = createClient(fetchFn, {}, tokenManager);
+      client.setAuthToken(expiringToken);
+
+      const token = client.getValidAccessToken();
+      await vi.waitFor(() => expect(fetchFn).toHaveBeenCalledOnce());
+      client.setAuthToken('new-token');
+      resolveRefresh(
+        createJsonResponse(401, {
+          error: 'AUTH_UNAUTHORIZED',
+          message: 'Refresh token is invalid',
+          statusCode: 401,
+        })
+      );
+
+      await expect(token).rejects.toMatchObject({ statusCode: 401 });
+      expect(tokenManager.clearSession).not.toHaveBeenCalled();
+      expect(client.getHeaders().Authorization).toBe('Bearer new-token');
+    });
   });
 
   describe('basic requests', () => {

--- a/src/lib/__tests__/http-client.test.ts
+++ b/src/lib/__tests__/http-client.test.ts
@@ -20,6 +20,13 @@ function createJsonResponse(status: number, body: any, statusText = 'OK'): Respo
   } as Response;
 }
 
+function jwt(expirationOffsetSeconds: number): string {
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expirationOffsetSeconds })
+  ).toString('base64url');
+  return `header.${payload}.signature`;
+}
+
 function createMockTokenManager(): TokenManager {
   return {
     saveSession: vi.fn(),
@@ -66,6 +73,28 @@ describe('HttpClient', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+  });
+
+  describe('getValidAccessToken', () => {
+    it('refreshes an expiring browser token before a new handshake can use it', async () => {
+      const tokenManager = createMockTokenManager();
+      const expiringToken = jwt(30);
+      const refreshedToken = jwt(600);
+      (tokenManager.getAccessToken as ReturnType<typeof vi.fn>).mockReturnValue(expiringToken);
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValue(
+          createJsonResponse(200, { accessToken: refreshedToken, user: { id: 'user-1' } })
+        );
+      const client = createClient(fetchFn, {}, tokenManager);
+      client.setAuthToken(expiringToken);
+
+      await expect(client.getValidAccessToken()).resolves.toBe(refreshedToken);
+      expect(tokenManager.saveSession).toHaveBeenCalledWith(
+        { accessToken: refreshedToken, user: { id: 'user-1' } },
+        'tokenRefreshed'
+      );
+    });
   });
 
   describe('basic requests', () => {

--- a/src/lib/__tests__/token-manager.test.ts
+++ b/src/lib/__tests__/token-manager.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TokenManager } from '../token-manager';
+
+describe('TokenManager auth-state listeners', () => {
+  it('isolates a throwing listener so later listeners and callers continue', () => {
+    const tokenManager = new TokenManager();
+    const secondListener = vi.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    tokenManager.onAuthStateChange(() => {
+      throw new Error('listener failed');
+    });
+    tokenManager.onAuthStateChange(secondListener);
+
+    expect(() => tokenManager.setAccessToken('token')).not.toThrow();
+    expect(secondListener).toHaveBeenCalledWith('signedIn');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -1,6 +1,12 @@
 import { InsForgeConfig, ApiError, InsForgeError, AuthRefreshResponse } from '../types';
 import { Logger } from './logger';
-import { clearCsrfToken, getCsrfToken, setCsrfToken, TokenManager } from './token-manager';
+import {
+  AuthChangeEvent,
+  clearCsrfToken,
+  getCsrfToken,
+  setCsrfToken,
+  TokenManager,
+} from './token-manager';
 import { isJwtExpiredOrExpiring } from './jwt';
 
 type JsonRequestBody = Record<string, unknown> | unknown[] | null;
@@ -722,7 +728,7 @@ export class HttpClient {
   private async refreshAndSaveSession(): Promise<AuthRefreshResponse> {
     const newTokenData = await this.refreshAccessToken();
     this.setAuthToken(newTokenData.accessToken);
-    this.tokenManager.saveSession(newTokenData, 'tokenRefreshed');
+    this.tokenManager.saveSession(newTokenData, AuthChangeEvent.TOKEN_REFRESHED);
     if (newTokenData.csrfToken) {
       setCsrfToken(newTokenData.csrfToken);
     }

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -704,8 +704,18 @@ export class HttpClient {
       return accessToken;
     }
 
-    const refreshed = await this.refreshAndSaveSession();
-    return refreshed.accessToken;
+    try {
+      const refreshed = await this.refreshAndSaveSession();
+      return refreshed.accessToken;
+    } catch (error) {
+      if (
+        error instanceof InsForgeError &&
+        (error.statusCode === 401 || error.statusCode === 403)
+      ) {
+        this.clearAuthSession();
+      }
+      throw error;
+    }
   }
 
   private async refreshAndSaveSession(): Promise<AuthRefreshResponse> {

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -710,7 +710,8 @@ export class HttpClient {
     } catch (error) {
       if (
         error instanceof InsForgeError &&
-        (error.statusCode === 401 || error.statusCode === 403)
+        (error.statusCode === 401 || error.statusCode === 403) &&
+        this.userToken === accessToken
       ) {
         this.clearAuthSession();
       }

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -1,6 +1,7 @@
 import { InsForgeConfig, ApiError, InsForgeError, AuthRefreshResponse } from '../types';
 import { Logger } from './logger';
 import { clearCsrfToken, getCsrfToken, setCsrfToken, TokenManager } from './token-manager';
+import { isJwtExpiredOrExpiring } from './jwt';
 
 type JsonRequestBody = Record<string, unknown> | unknown[] | null;
 export interface RequestOptions extends Omit<RequestInit, 'body'> {
@@ -687,10 +688,30 @@ export class HttpClient {
     return this.refreshPromise;
   }
 
+  /** Returns a token safe to use for a new connection handshake. */
+  async getValidAccessToken(leewaySeconds = 60): Promise<string | null> {
+    const accessToken = this.tokenManager.getAccessToken() ?? this.userToken;
+    if (!accessToken || !isJwtExpiredOrExpiring(accessToken, leewaySeconds)) {
+      return accessToken;
+    }
+
+    const canRefresh =
+      !this.config.isServerMode &&
+      !this.config.accessToken &&
+      !this.config.edgeFunctionToken &&
+      this.userToken !== null;
+    if (!canRefresh) {
+      return accessToken;
+    }
+
+    const refreshed = await this.refreshAndSaveSession();
+    return refreshed.accessToken;
+  }
+
   private async refreshAndSaveSession(): Promise<AuthRefreshResponse> {
     const newTokenData = await this.refreshAccessToken();
     this.setAuthToken(newTokenData.accessToken);
-    this.tokenManager.saveSession(newTokenData);
+    this.tokenManager.saveSession(newTokenData, 'tokenRefreshed');
     if (newTokenData.csrfToken) {
       setCsrfToken(newTokenData.csrfToken);
     }

--- a/src/lib/token-manager.ts
+++ b/src/lib/token-manager.ts
@@ -7,7 +7,13 @@
 import type { UserSchema } from '@insforge/shared-schemas';
 import type { AuthSession } from '../types';
 
-export type AuthChangeEvent = 'signedIn' | 'signedOut' | 'tokenRefreshed';
+export const AuthChangeEvent = {
+  SIGNED_IN: 'signedIn',
+  SIGNED_OUT: 'signedOut',
+  TOKEN_REFRESHED: 'tokenRefreshed',
+} as const;
+
+export type AuthChangeEvent = (typeof AuthChangeEvent)[keyof typeof AuthChangeEvent];
 export type AuthStateChangeCallback = (event: AuthChangeEvent) => void;
 
 // CSRF token cookie name
@@ -69,7 +75,7 @@ export class TokenManager {
   /**
    * Save session in memory
    */
-  saveSession(session: AuthSession, event: AuthChangeEvent = 'signedIn'): void {
+  saveSession(session: AuthSession, event: AuthChangeEvent = AuthChangeEvent.SIGNED_IN): void {
     const tokenChanged = session.accessToken !== this.accessToken;
     this.accessToken = session.accessToken;
     this.user = session.user;
@@ -102,7 +108,7 @@ export class TokenManager {
   /**
    * Set access token
    */
-  setAccessToken(token: string, event: AuthChangeEvent = 'signedIn'): void {
+  setAccessToken(token: string, event: AuthChangeEvent = AuthChangeEvent.SIGNED_IN): void {
     const tokenChanged = token !== this.accessToken;
     this.accessToken = token;
     if (tokenChanged) {
@@ -133,7 +139,7 @@ export class TokenManager {
     this.user = null;
 
     if (hadToken) {
-      this.notifyAuthStateChange('signedOut');
+      this.notifyAuthStateChange(AuthChangeEvent.SIGNED_OUT);
     }
   }
 

--- a/src/lib/token-manager.ts
+++ b/src/lib/token-manager.ts
@@ -7,6 +7,9 @@
 import type { UserSchema } from '@insforge/shared-schemas';
 import type { AuthSession } from '../types';
 
+export type AuthChangeEvent = 'signedIn' | 'signedOut' | 'tokenRefreshed';
+export type AuthStateChangeCallback = (event: AuthChangeEvent) => void;
+
 // CSRF token cookie name
 export const CSRF_TOKEN_COOKIE = 'insforge_csrf_token';
 
@@ -59,21 +62,20 @@ export class TokenManager {
   private accessToken: string | null = null;
   private user: UserSchema | null = null;
 
-  // Callback for token changes (used by realtime to reconnect with new token)
-  onTokenChange: (() => void) | null = null;
+  private authStateChangeCallbacks = new Map<symbol, AuthStateChangeCallback>();
 
   constructor() {}
 
   /**
    * Save session in memory
    */
-  saveSession(session: AuthSession): void {
+  saveSession(session: AuthSession, event: AuthChangeEvent = 'signedIn'): void {
     const tokenChanged = session.accessToken !== this.accessToken;
     this.accessToken = session.accessToken;
     this.user = session.user;
 
-    if (tokenChanged && this.onTokenChange) {
-      this.onTokenChange();
+    if (tokenChanged) {
+      this.notifyAuthStateChange(event);
     }
   }
 
@@ -100,11 +102,11 @@ export class TokenManager {
   /**
    * Set access token
    */
-  setAccessToken(token: string): void {
+  setAccessToken(token: string, event: AuthChangeEvent = 'signedIn'): void {
     const tokenChanged = token !== this.accessToken;
     this.accessToken = token;
-    if (tokenChanged && this.onTokenChange) {
-      this.onTokenChange();
+    if (tokenChanged) {
+      this.notifyAuthStateChange(event);
     }
   }
 
@@ -130,8 +132,20 @@ export class TokenManager {
     this.accessToken = null;
     this.user = null;
 
-    if (hadToken && this.onTokenChange) {
-      this.onTokenChange();
+    if (hadToken) {
+      this.notifyAuthStateChange('signedOut');
+    }
+  }
+
+  onAuthStateChange(callback: AuthStateChangeCallback): () => void {
+    const id = Symbol('auth-state-change');
+    this.authStateChangeCallbacks.set(id, callback);
+    return () => this.authStateChangeCallbacks.delete(id);
+  }
+
+  private notifyAuthStateChange(event: AuthChangeEvent): void {
+    for (const callback of this.authStateChangeCallbacks.values()) {
+      callback(event);
     }
   }
 }

--- a/src/lib/token-manager.ts
+++ b/src/lib/token-manager.ts
@@ -145,7 +145,11 @@ export class TokenManager {
 
   private notifyAuthStateChange(event: AuthChangeEvent): void {
     for (const callback of this.authStateChangeCallbacks.values()) {
-      callback(event);
+      try {
+        callback(event);
+      } catch (error) {
+        console.error('Error in auth state change callback:', error);
+      }
     }
   }
 }

--- a/src/modules/__tests__/realtime.test.ts
+++ b/src/modules/__tests__/realtime.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SubscribeResponse } from '@insforge/shared-schemas';
+import type {
+  PresenceJoinMessage,
+  PresenceLeaveMessage,
+  SubscribeResponse,
+} from '@insforge/shared-schemas';
 import { Realtime } from '../realtime';
 import { TokenManager } from '../../lib/token-manager';
 
@@ -26,6 +30,25 @@ class FakeSocket {
     return this;
   }
 
+  off(event: string, listener?: Listener): this {
+    if (listener) {
+      this.listeners.set(
+        event,
+        (this.listeners.get(event) ?? []).filter((candidate) => candidate !== listener)
+      );
+    } else {
+      this.listeners.delete(event);
+    }
+    return this;
+  }
+
+  offAny(listener?: Listener): this {
+    this.anyListeners = listener
+      ? this.anyListeners.filter((candidate) => candidate !== listener)
+      : [];
+    return this;
+  }
+
   trigger(event: string, ...args: unknown[]): void {
     if (event === 'connect') {
       this.connected = true;
@@ -37,16 +60,17 @@ class FakeSocket {
       listener(...args);
     }
   }
+
+  triggerAny(event: string, message: unknown): void {
+    for (const listener of this.anyListeners) {
+      listener(event, message);
+    }
+  }
 }
 
 let socket: FakeSocket;
 let socketOptions: { auth?: unknown } | undefined;
-
-const io = vi.fn((_url: string, options: { auth?: unknown }) => {
-  socketOptions = options;
-  socket = new FakeSocket();
-  return socket;
-});
+const { io } = vi.hoisted(() => ({ io: vi.fn() }));
 
 vi.mock('socket.io-client', () => ({ io }));
 
@@ -73,8 +97,14 @@ function latestSubscribeAck(): (response: SubscribeResponse) => void {
 describe('Realtime', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     socket = undefined as never;
     socketOptions = undefined;
+    io.mockImplementation((_url: string, options: { auth?: unknown }) => {
+      socketOptions = options;
+      socket = new FakeSocket();
+      return socket;
+    });
   });
 
   it('keeps an established socket connected when an access token is refreshed', async () => {
@@ -87,6 +117,18 @@ describe('Realtime', () => {
 
     expect(socket.disconnect).not.toHaveBeenCalled();
     expect(socket.connect).not.toHaveBeenCalled();
+  });
+
+  it('reconnects an established socket when the authentication identity changes', async () => {
+    const tokens = new TokenManager();
+    tokens.setAccessToken(jwt(300));
+    const realtime = new Realtime('http://example.test', tokens);
+    await connect(realtime);
+
+    tokens.setAccessToken(jwt(600), 'signedIn');
+
+    expect(socket.disconnect).toHaveBeenCalledOnce();
+    expect(socket.connect).toHaveBeenCalledOnce();
   });
 
   it('reads the latest token each time Socket.IO performs a handshake', async () => {
@@ -143,6 +185,71 @@ describe('Realtime', () => {
     acknowledge({ ok: true, channel: 'room', presence: { members: [] } });
 
     await expect(realtime.subscribe('room')).resolves.toMatchObject({ ok: true, channel: 'room' });
+  });
+
+  it('ignores an acknowledgement that arrives after a subscription timeout', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    await connect(realtime);
+    vi.useFakeTimers();
+    const subscription = realtime.subscribe('room');
+    const acknowledge = latestSubscribeAck();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(subscription).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'SUBSCRIBE_TIMEOUT' },
+    });
+
+    acknowledge({ ok: true, channel: 'room', presence: { members: [] } });
+    expect((realtime as any).subscriptions.get('room')?.state).toBe('joining');
+  });
+
+  it('disposes a failed connection attempt before a later attempt starts', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    const firstConnection = realtime.connect();
+    await vi.waitFor(() => expect(socket).toBeDefined());
+    const failedSocket = socket;
+
+    failedSocket.trigger('connect_error', new Error('refused'));
+    await expect(firstConnection).rejects.toThrow('refused');
+    expect(failedSocket.disconnect).toHaveBeenCalledOnce();
+
+    const secondConnection = realtime.connect();
+    await vi.waitFor(() => expect(socket).not.toBe(failedSocket));
+    const activeSocket = socket;
+    failedSocket.trigger('connect');
+    expect(realtime.isConnected).toBe(false);
+    activeSocket.trigger('connect');
+    await expect(secondConnection).resolves.toBeUndefined();
+  });
+
+  it('updates presence state from join and leave events', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    await connect(realtime);
+    const subscription = realtime.subscribe('room');
+    await vi.waitFor(() => expect(latestSubscribeAck()).toBeTypeOf('function'));
+    latestSubscribeAck()({ ok: true, channel: 'room', presence: { members: [] } });
+    await subscription;
+    const member = {
+      type: 'user' as const,
+      presenceId: 'user-1',
+      joinedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const message = {
+      member,
+      meta: {
+        channel: 'room',
+        messageId: '00000000-0000-0000-0000-000000000001',
+        senderType: 'system' as const,
+        timestamp: '2026-01-01T00:00:00.000Z',
+      },
+    };
+
+    socket.triggerAny('presence:join', message as PresenceJoinMessage);
+    expect(realtime.getPresenceState('room')).toEqual([member]);
+
+    socket.triggerAny('presence:leave', message as PresenceLeaveMessage);
+    expect(realtime.getPresenceState('room')).toEqual([]);
   });
 
   it('re-subscribes with an acknowledgement after reconnect and replaces the presence snapshot', async () => {

--- a/src/modules/__tests__/realtime.test.ts
+++ b/src/modules/__tests__/realtime.test.ts
@@ -178,11 +178,80 @@ describe('Realtime', () => {
       channel: 'room',
       error: { code: 'DISCONNECTED' },
     });
-    expect(realtime.getSubscribedChannels()).toEqual(['room']);
+    expect(realtime.getSubscribedChannels()).toEqual([]);
 
     socket.trigger('connect');
     const acknowledge = latestSubscribeAck();
     acknowledge({ ok: true, channel: 'room', presence: { members: [] } });
+
+    await expect(realtime.subscribe('room')).resolves.toMatchObject({ ok: true, channel: 'room' });
+  });
+
+  it('pauses a server-rejected subscription until the caller explicitly retries it', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    await connect(realtime);
+
+    const rejected = realtime.subscribe('room');
+    await vi.waitFor(() => expect(latestSubscribeAck()).toBeTypeOf('function'));
+    latestSubscribeAck()({
+      ok: false,
+      channel: 'room',
+      error: {
+        code: 'REALTIME_UNAUTHORIZED',
+        message: 'Not authorized to subscribe to this channel',
+      },
+    });
+
+    await expect(rejected).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'REALTIME_UNAUTHORIZED' },
+    });
+    expect(realtime.getSubscribedChannels()).toEqual([]);
+
+    socket.trigger('disconnect', 'transport close');
+    socket.trigger('connect');
+    expect(socket.emit.mock.calls.filter(([event]) => event === 'realtime:subscribe')).toHaveLength(
+      1
+    );
+
+    const retried = realtime.subscribe('room');
+    await vi.waitFor(() =>
+      expect(
+        socket.emit.mock.calls.filter(([event]) => event === 'realtime:subscribe')
+      ).toHaveLength(2)
+    );
+    latestSubscribeAck()({ ok: true, channel: 'room', presence: { members: [] } });
+
+    await expect(retried).resolves.toMatchObject({ ok: true, channel: 'room' });
+    expect(realtime.getSubscribedChannels()).toEqual(['room']);
+  });
+
+  it('retries a rejected subscription after an authentication-boundary reconnect', async () => {
+    const tokens = new TokenManager();
+    tokens.setAccessToken(jwt(300));
+    const realtime = new Realtime('http://example.test', tokens);
+    await connect(realtime);
+
+    const rejected = realtime.subscribe('room');
+    await vi.waitFor(() => expect(latestSubscribeAck()).toBeTypeOf('function'));
+    latestSubscribeAck()({
+      ok: false,
+      channel: 'room',
+      error: {
+        code: 'REALTIME_UNAUTHORIZED',
+        message: 'Not authorized to subscribe to this channel',
+      },
+    });
+    await expect(rejected).resolves.toMatchObject({ ok: false });
+
+    tokens.setAccessToken(jwt(600), 'signedIn');
+    socket.trigger('connect');
+    await vi.waitFor(() =>
+      expect(
+        socket.emit.mock.calls.filter(([event]) => event === 'realtime:subscribe')
+      ).toHaveLength(2)
+    );
+    latestSubscribeAck()({ ok: true, channel: 'room', presence: { members: [] } });
 
     await expect(realtime.subscribe('room')).resolves.toMatchObject({ ok: true, channel: 'room' });
   });
@@ -201,7 +270,7 @@ describe('Realtime', () => {
     });
 
     acknowledge({ ok: true, channel: 'room', presence: { members: [] } });
-    expect((realtime as any).subscriptions.get('room')?.state).toBe('joining');
+    expect((realtime as any).subscriptions.get('room')?.status).toBe('pending');
   });
 
   it('disposes a failed connection attempt before a later attempt starts', async () => {

--- a/src/modules/__tests__/realtime.test.ts
+++ b/src/modules/__tests__/realtime.test.ts
@@ -235,6 +235,10 @@ describe('Realtime', () => {
       presenceId: 'user-1',
       joinedAt: '2026-01-01T00:00:00.000Z',
     };
+
+    expect(() => socket.triggerAny('presence:join', { member })).not.toThrow();
+    expect(realtime.getPresenceState('room')).toEqual([]);
+
     const message = {
       member,
       meta: {

--- a/src/modules/__tests__/realtime.test.ts
+++ b/src/modules/__tests__/realtime.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SubscribeResponse } from '@insforge/shared-schemas';
+import { Realtime } from '../realtime';
+import { TokenManager } from '../../lib/token-manager';
+
+type Listener = (...args: any[]) => void;
+
+class FakeSocket {
+  connected = false;
+  id = 'socket-1';
+  disconnect = vi.fn(() => {
+    this.connected = false;
+  });
+  connect = vi.fn();
+  emit = vi.fn();
+  private listeners = new Map<string, Listener[]>();
+  private anyListeners: Listener[] = [];
+
+  on(event: string, listener: Listener): this {
+    this.listeners.set(event, [...(this.listeners.get(event) ?? []), listener]);
+    return this;
+  }
+
+  onAny(listener: Listener): this {
+    this.anyListeners.push(listener);
+    return this;
+  }
+
+  trigger(event: string, ...args: unknown[]): void {
+    if (event === 'connect') {
+      this.connected = true;
+    }
+    if (event === 'disconnect') {
+      this.connected = false;
+    }
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+let socket: FakeSocket;
+let socketOptions: { auth?: unknown } | undefined;
+
+const io = vi.fn((_url: string, options: { auth?: unknown }) => {
+  socketOptions = options;
+  socket = new FakeSocket();
+  return socket;
+});
+
+vi.mock('socket.io-client', () => ({ io }));
+
+function jwt(expirationOffsetSeconds: number): string {
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expirationOffsetSeconds })
+  ).toString('base64url');
+  return `header.${payload}.signature`;
+}
+
+async function connect(realtime: Realtime): Promise<FakeSocket> {
+  const promise = realtime.connect();
+  await vi.waitFor(() => expect(socket).toBeDefined());
+  socket.trigger('connect');
+  await promise;
+  return socket;
+}
+
+function latestSubscribeAck(): (response: SubscribeResponse) => void {
+  const calls = socket.emit.mock.calls.filter(([event]) => event === 'realtime:subscribe');
+  return calls.at(-1)?.[2] as (response: SubscribeResponse) => void;
+}
+
+describe('Realtime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socket = undefined as never;
+    socketOptions = undefined;
+  });
+
+  it('keeps an established socket connected when an access token is refreshed', async () => {
+    const tokens = new TokenManager();
+    tokens.setAccessToken(jwt(300));
+    const realtime = new Realtime('http://example.test', tokens);
+    await connect(realtime);
+
+    tokens.setAccessToken(jwt(600), 'tokenRefreshed');
+
+    expect(socket.disconnect).not.toHaveBeenCalled();
+    expect(socket.connect).not.toHaveBeenCalled();
+  });
+
+  it('reads the latest token each time Socket.IO performs a handshake', async () => {
+    const tokens = new TokenManager();
+    tokens.setAccessToken(jwt(300));
+    const realtime = new Realtime('http://example.test', tokens);
+    await connect(realtime);
+
+    const refreshedToken = jwt(600);
+    tokens.setAccessToken(refreshedToken, 'tokenRefreshed');
+
+    if (typeof socketOptions?.auth !== 'function') {
+      expect(socketOptions?.auth).toBeTypeOf('function');
+      return;
+    }
+    const auth = socketOptions.auth as (callback: (payload: { token?: string }) => void) => void;
+    const callback = vi.fn();
+    auth(callback);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith({ token: refreshedToken }));
+  });
+
+  it('does not restore a subscription when an acknowledgement arrives after unsubscribe', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    await connect(realtime);
+    const subscription = realtime.subscribe('room');
+    await vi.waitFor(() => expect(latestSubscribeAck()).toBeTypeOf('function'));
+
+    const acknowledge = latestSubscribeAck();
+    realtime.unsubscribe('room');
+    acknowledge({ ok: true, channel: 'room', presence: { members: [] } });
+
+    expect((realtime as any).subscriptions.get('room')).toBeUndefined();
+    await expect(subscription).resolves.toMatchObject({ ok: false, channel: 'room' });
+    expect(realtime.getSubscribedChannels()).toEqual([]);
+  });
+
+  it('settles an in-flight subscription on disconnect and retries it after reconnect', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    await connect(realtime);
+    const subscription = realtime.subscribe('room');
+    await vi.waitFor(() => expect(latestSubscribeAck()).toBeTypeOf('function'));
+
+    socket.trigger('disconnect', 'transport close');
+
+    await expect(subscription).resolves.toMatchObject({
+      ok: false,
+      channel: 'room',
+      error: { code: 'DISCONNECTED' },
+    });
+    expect(realtime.getSubscribedChannels()).toEqual(['room']);
+
+    socket.trigger('connect');
+    const acknowledge = latestSubscribeAck();
+    acknowledge({ ok: true, channel: 'room', presence: { members: [] } });
+
+    await expect(realtime.subscribe('room')).resolves.toMatchObject({ ok: true, channel: 'room' });
+  });
+
+  it('re-subscribes with an acknowledgement after reconnect and replaces the presence snapshot', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    await connect(realtime);
+    const subscription = realtime.subscribe('room');
+    await vi.waitFor(() => expect(latestSubscribeAck()).toBeTypeOf('function'));
+    latestSubscribeAck()({
+      ok: true,
+      channel: 'room',
+      presence: {
+        members: [{ type: 'user', presenceId: 'user-1', joinedAt: '2026-01-01T00:00:00.000Z' }],
+      },
+    });
+    expect((realtime as any).subscriptions.get('room')?.pending).toBeUndefined();
+    await subscription;
+
+    socket.trigger('disconnect', 'transport close');
+    socket.trigger('connect');
+
+    const acknowledge = latestSubscribeAck();
+    expect(acknowledge).toBeTypeOf('function');
+    acknowledge({
+      ok: true,
+      channel: 'room',
+      presence: {
+        members: [{ type: 'user', presenceId: 'user-2', joinedAt: '2026-01-01T00:00:00.000Z' }],
+      },
+    });
+
+    expect(realtime.getPresenceState('room')).toEqual([
+      { type: 'user', presenceId: 'user-2', joinedAt: '2026-01-01T00:00:00.000Z' },
+    ]);
+  });
+});

--- a/src/modules/__tests__/realtime.test.ts
+++ b/src/modules/__tests__/realtime.test.ts
@@ -187,6 +187,32 @@ describe('Realtime', () => {
     await expect(realtime.subscribe('room')).resolves.toMatchObject({ ok: true, channel: 'room' });
   });
 
+  it('ignores a disconnected socket acknowledgement before resubscribing', async () => {
+    const realtime = new Realtime('http://example.test', new TokenManager());
+    await connect(realtime);
+    const subscription = realtime.subscribe('room');
+    await vi.waitFor(() => expect(latestSubscribeAck()).toBeTypeOf('function'));
+    const staleAcknowledge = latestSubscribeAck();
+
+    socket.trigger('disconnect', 'transport close');
+    await expect(subscription).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'DISCONNECTED' },
+    });
+
+    staleAcknowledge({ ok: true, channel: 'room', presence: { members: [] } });
+    socket.trigger('connect');
+
+    expect(socket.emit.mock.calls.filter(([event]) => event === 'realtime:subscribe')).toHaveLength(
+      2
+    );
+
+    const resubscription = realtime.subscribe('room');
+    latestSubscribeAck()({ ok: true, channel: 'room', presence: { members: [] } });
+    await expect(resubscription).resolves.toMatchObject({ ok: true, channel: 'room' });
+    expect(realtime.getSubscribedChannels()).toEqual(['room']);
+  });
+
   it('pauses a server-rejected subscription until the caller explicitly retries it', async () => {
     const realtime = new Realtime('http://example.test', new TokenManager());
     await connect(realtime);

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -6,11 +6,11 @@
 import { HttpClient } from '../../lib/http-client';
 import {
   TokenManager,
+  AuthChangeEvent,
   getCsrfToken,
   setCsrfToken,
   clearCsrfToken,
   type AuthStateChangeCallback,
-  type AuthChangeEvent,
 } from '../../lib/token-manager';
 import { AuthSession, InsForgeError } from '../../types';
 import {
@@ -89,7 +89,7 @@ export class Auth {
   private saveSessionFromResponse(
     response:
       CreateUserResponse | CreateSessionResponse | VerifyEmailResponse | RefreshSessionResponse,
-    event: AuthChangeEvent = 'signedIn'
+    event: AuthChangeEvent = AuthChangeEvent.SIGNED_IN
   ): boolean {
     if (!response.accessToken || !response.user) {
       return false;
@@ -469,7 +469,7 @@ export class Auth {
       );
 
       if (response.accessToken) {
-        this.saveSessionFromResponse(response, 'tokenRefreshed');
+        this.saveSessionFromResponse(response, AuthChangeEvent.TOKEN_REFRESHED);
       }
 
       return { data: response, error: null };

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -4,7 +4,14 @@
  */
 
 import { HttpClient } from '../../lib/http-client';
-import { TokenManager, getCsrfToken, setCsrfToken, clearCsrfToken } from '../../lib/token-manager';
+import {
+  TokenManager,
+  getCsrfToken,
+  setCsrfToken,
+  clearCsrfToken,
+  type AuthStateChangeCallback,
+  type AuthChangeEvent,
+} from '../../lib/token-manager';
 import { AuthSession, InsForgeError } from '../../types';
 import {
   generateCodeVerifier,
@@ -70,13 +77,19 @@ export class Auth {
     return !!this.options.isServerMode;
   }
 
+  /** Subscribe to SDK authentication state changes. */
+  onAuthStateChange(callback: AuthStateChangeCallback): () => void {
+    return this.tokenManager.onAuthStateChange(callback);
+  }
+
   /**
    * Save session from API response
    * Handles token storage, CSRF token, and HTTP auth header
    */
   private saveSessionFromResponse(
     response:
-      CreateUserResponse | CreateSessionResponse | VerifyEmailResponse | RefreshSessionResponse
+      CreateUserResponse | CreateSessionResponse | VerifyEmailResponse | RefreshSessionResponse,
+    event: AuthChangeEvent = 'signedIn'
   ): boolean {
     if (!response.accessToken || !response.user) {
       return false;
@@ -93,7 +106,7 @@ export class Auth {
     }
 
     if (!this.isServerMode()) {
-      this.tokenManager.saveSession(session);
+      this.tokenManager.saveSession(session, event);
     }
     this.http.setAuthToken(response.accessToken);
     this.http.setRefreshToken(response.refreshToken ?? null);
@@ -456,7 +469,7 @@ export class Auth {
       );
 
       if (response.accessToken) {
-        this.saveSessionFromResponse(response);
+        this.saveSessionFromResponse(response, 'tokenRefreshed');
       }
 
       return { data: response, error: null };

--- a/src/modules/realtime.ts
+++ b/src/modules/realtime.ts
@@ -14,12 +14,12 @@ export type { PresenceMember, RealtimeErrorPayload, SocketMessage, SubscribeResp
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected';
 export type EventCallback<T = unknown> = (payload: T) => void;
 
-type SubscriptionState = 'joining' | 'joined';
+type SubscriptionStatus = 'pending' | 'subscribed' | 'rejected';
 
 interface ChannelSubscription {
   channel: string;
   epoch: number;
-  state: SubscriptionState;
+  status: SubscriptionStatus;
   members: Map<string, PresenceMember>;
   pending?: Promise<SubscribeResponse>;
   settlePending?: (response: SubscribeResponse) => void;
@@ -219,6 +219,11 @@ export class Realtime {
   }
 
   private reconnectForAuthChange(): void {
+    for (const subscription of this.subscriptions.values()) {
+      if (subscription.status === 'rejected') {
+        subscription.status = 'pending';
+      }
+    }
     if (!this.socket) {
       return;
     }
@@ -228,7 +233,10 @@ export class Realtime {
 
   private handleDisconnect(reason: string): void {
     for (const subscription of this.subscriptions.values()) {
-      subscription.state = 'joining';
+      if (subscription.status === 'rejected') {
+        continue;
+      }
+      subscription.status = 'pending';
       this.settleSubscription(
         subscription,
         {
@@ -244,7 +252,9 @@ export class Realtime {
 
   private resubscribeChannels(): void {
     for (const [channel, subscription] of this.subscriptions) {
-      this.requestSubscription(channel, subscription);
+      if (subscription.status === 'pending') {
+        this.requestSubscription(channel, subscription);
+      }
     }
   }
 
@@ -264,7 +274,7 @@ export class Realtime {
       });
     }
 
-    subscription.state = 'joining';
+    subscription.status = 'pending';
     const epoch = ++subscription.epoch;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     subscription.pending = new Promise<SubscribeResponse>((resolve) => {
@@ -299,10 +309,13 @@ export class Realtime {
           return;
         }
         if (response.ok) {
-          subscription.state = 'joined';
+          subscription.status = 'subscribed';
           subscription.members = new Map(
             response.presence.members.map((member) => [member.presenceId, member])
           );
+        } else {
+          subscription.status = 'rejected';
+          subscription.members.clear();
         }
         this.settleSubscription(subscription, response, false);
       });
@@ -363,11 +376,11 @@ export class Realtime {
       if (subscription.pending) {
         return subscription.pending;
       }
-      if (subscription.state === 'joined') {
+      if (subscription.status === 'subscribed') {
         return { ok: true, channel, presence: { members: [...subscription.members.values()] } };
       }
     } else {
-      subscription = { channel, epoch: 0, state: 'joining', members: new Map() };
+      subscription = { channel, epoch: 0, status: 'pending', members: new Map() };
       this.subscriptions.set(channel, subscription);
     }
 
@@ -436,7 +449,11 @@ export class Realtime {
   }
 
   getSubscribedChannels(): string[] {
-    return [...this.subscriptions.keys()];
+    // Only server-confirmed subscriptions are active. Pending retries and
+    // server-rejected intents remain internal until they are explicitly retried.
+    return [...this.subscriptions.values()]
+      .filter((subscription) => subscription.status === 'subscribed')
+      .map((subscription) => subscription.channel);
   }
 
   getPresenceState(channel: string): PresenceMember[] {

--- a/src/modules/realtime.ts
+++ b/src/modules/realtime.ts
@@ -326,7 +326,7 @@ export class Realtime {
       return;
     }
     const presenceEvent = message as PresenceJoinMessage | PresenceLeaveMessage;
-    const channel = presenceEvent.meta.channel;
+    const channel = presenceEvent.meta?.channel;
     const member = presenceEvent.member;
     if (!channel || !member) {
       return;

--- a/src/modules/realtime.ts
+++ b/src/modules/realtime.ts
@@ -1,362 +1,402 @@
 import type { Socket } from 'socket.io-client';
 import type {
-  SubscribeResponse,
+  PresenceMember,
   RealtimeErrorPayload,
   SocketMessage,
+  SubscribeResponse,
 } from '@insforge/shared-schemas';
 import { TokenManager } from '../lib/token-manager';
 
-export type { SubscribeResponse, RealtimeErrorPayload, SocketMessage };
+export type { PresenceMember, RealtimeErrorPayload, SocketMessage, SubscribeResponse };
 
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected';
-
 export type EventCallback<T = unknown> = (payload: T) => void;
 
-const CONNECT_TIMEOUT = 10000;
+type SubscriptionState = 'joining' | 'joined';
+
+interface ChannelSubscription {
+  epoch: number;
+  state: SubscriptionState;
+  members: Map<string, PresenceMember>;
+  pending?: Promise<SubscribeResponse>;
+  settlePending?: (response: SubscribeResponse) => void;
+}
+
+const CONNECT_TIMEOUT = 10_000;
+const SUBSCRIBE_TIMEOUT = 10_000;
 
 /**
- * Realtime module for subscribing to channels and handling real-time events
- *
- * @example
- * ```typescript
- * const { realtime } = client;
- *
- * // Connect to the realtime server
- * await realtime.connect();
- *
- * // Subscribe to a channel
- * const response = await realtime.subscribe('orders:123');
- * if (!response.ok) {
- *   console.error('Failed to subscribe:', response.error);
- * }
- *
- * // Listen for specific events
- * realtime.on('order_updated', (payload) => {
- *   console.log('Order updated:', payload);
- * });
- *
- * // Listen for connection events
- * realtime.on('connect', () => console.log('Connected!'));
- * realtime.on('connect_error', (err) => console.error('Connection failed:', err));
- * realtime.on('disconnect', (reason) => console.log('Disconnected:', reason));
- * realtime.on('error', (error) => console.error('Realtime error:', error));
- *
- * // Publish a message to a channel
- * await realtime.publish('orders:123', 'status_changed', { status: 'shipped' });
- *
- * // Unsubscribe and disconnect when done
- * realtime.unsubscribe('orders:123');
- * realtime.disconnect();
- * ```
+ * Socket.IO realtime client. Authentication is evaluated for every handshake,
+ * while an established socket remains authenticated until it disconnects.
  */
 export class Realtime {
-  private baseUrl: string;
-  private tokenManager: TokenManager;
   private socket: Socket | null = null;
   private connectPromise: Promise<void> | null = null;
-  private subscribedChannels: Set<string> = new Set();
-  private eventListeners: Map<string, Set<EventCallback>> = new Map();
-  private anonKey?: string;
+  private subscriptions = new Map<string, ChannelSubscription>();
+  private eventListeners = new Map<string, Set<EventCallback>>();
 
-  constructor(baseUrl: string, tokenManager: TokenManager, anonKey?: string) {
-    this.baseUrl = baseUrl;
-    this.tokenManager = tokenManager;
-    this.anonKey = anonKey;
-
-    // Handle token changes (e.g., after refresh)
-    this.tokenManager.onTokenChange = () => this.onTokenChange();
+  constructor(
+    private baseUrl: string,
+    private tokenManager: TokenManager,
+    private anonKey?: string,
+    private getValidAccessToken: () => Promise<string | null> = async () =>
+      tokenManager.getAccessToken()
+  ) {
+    this.tokenManager.onAuthStateChange((event) => {
+      if (event !== 'tokenRefreshed') {
+        this.reconnectForAuthChange();
+      }
+    });
   }
 
   private notifyListeners(event: string, payload?: unknown): void {
-    const listeners = this.eventListeners.get(event);
-    if (!listeners) {
-      return;
-    }
-    for (const cb of listeners) {
+    for (const callback of this.eventListeners.get(event) ?? []) {
       try {
-        cb(payload);
-      } catch (err) {
-        console.error(`Error in ${event} callback:`, err);
+        callback(payload);
+      } catch (error) {
+        console.error(`Error in ${event} callback:`, error);
       }
     }
   }
 
-  /**
-   * Connect to the realtime server
-   * @returns Promise that resolves when connected
-   */
+  private async getHandshakeToken(): Promise<string | null> {
+    return (await this.getValidAccessToken()) ?? this.anonKey ?? null;
+  }
+
   connect(): Promise<void> {
-    // Already connected
     if (this.socket?.connected) {
       return Promise.resolve();
     }
-
-    // Connection already in progress, return existing promise
     if (this.connectPromise) {
       return this.connectPromise;
     }
 
     this.connectPromise = (async () => {
-      try {
-        const { io } = await import('socket.io-client');
+      const { io } = await import('socket.io-client');
 
-        await new Promise<void>((resolve, reject) => {
-          const token = this.tokenManager.getAccessToken() ?? this.anonKey;
-
-          this.socket = io(this.baseUrl, {
-            transports: ['websocket'],
-            auth: token ? { token } : undefined,
-          });
-
-          let initialConnection = true;
-          let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-          const cleanup = () => {
-            if (timeoutId) {
-              clearTimeout(timeoutId);
-              timeoutId = null;
-            }
-          };
-
-          timeoutId = setTimeout(() => {
-            if (initialConnection) {
-              initialConnection = false;
-              this.connectPromise = null;
-              this.socket?.disconnect();
-              this.socket = null;
-              reject(new Error(`Connection timeout after ${CONNECT_TIMEOUT}ms`));
-            }
-          }, CONNECT_TIMEOUT);
-
-          this.socket.on('connect', () => {
-            cleanup();
-            // Re-subscribe to channels on every connect (initial + reconnects)
-            for (const channel of this.subscribedChannels) {
-              this.socket!.emit('realtime:subscribe', { channel });
-            }
-            this.notifyListeners('connect');
-
-            if (initialConnection) {
-              initialConnection = false;
-              this.connectPromise = null;
-              resolve();
-            }
-          });
-
-          this.socket.on('connect_error', (error: Error) => {
-            cleanup();
-            this.notifyListeners('connect_error', error);
-
-            if (initialConnection) {
-              initialConnection = false;
-              this.connectPromise = null;
-              reject(error);
-            }
-          });
-
-          this.socket.on('disconnect', (reason: string) => {
-            this.notifyListeners('disconnect', reason);
-          });
-
-          this.socket.on('realtime:error', (error: RealtimeErrorPayload) => {
-            this.notifyListeners('error', error);
-          });
-
-          // Route custom events to listeners (onAny doesn't catch socket reserved events)
-          this.socket.onAny((event: string, message: SocketMessage) => {
-            if (event === 'realtime:error') {
-              return;
-            } // Already handled above
-            this.notifyListeners(event, message);
-          });
+      await new Promise<void>((resolve, reject) => {
+        this.socket = io(this.baseUrl, {
+          transports: ['websocket'],
+          auth: (callback) => {
+            void this.getHandshakeToken().then(
+              (token) => callback(token ? { token } : {}),
+              () => callback({})
+            );
+          },
         });
-      } catch (error) {
-        this.connectPromise = null;
-        throw error;
-      }
-    })();
+
+        let initialConnection = true;
+        let timeoutId: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+          if (!initialConnection) {
+            return;
+          }
+          initialConnection = false;
+          this.connectPromise = null;
+          this.socket?.disconnect();
+          this.socket = null;
+          reject(new Error(`Connection timeout after ${CONNECT_TIMEOUT}ms`));
+        }, CONNECT_TIMEOUT);
+
+        const clearConnectTimeout = () => {
+          if (timeoutId) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+          }
+        };
+
+        this.socket.on('connect', () => {
+          clearConnectTimeout();
+          this.resubscribeChannels();
+          this.notifyListeners('connect');
+          if (initialConnection) {
+            initialConnection = false;
+            this.connectPromise = null;
+            resolve();
+          }
+        });
+
+        this.socket.on('connect_error', (error: Error) => {
+          clearConnectTimeout();
+          this.notifyListeners('connect_error', error);
+          if (initialConnection) {
+            initialConnection = false;
+            this.connectPromise = null;
+            reject(error);
+          }
+        });
+
+        this.socket.on('disconnect', (reason: string) => {
+          this.handleDisconnect(reason);
+        });
+
+        this.socket.on('realtime:error', (error: RealtimeErrorPayload) => {
+          this.notifyListeners('error', error);
+        });
+
+        this.socket.onAny((event: string, message: SocketMessage) => {
+          if (event === 'realtime:error') {
+            return;
+          }
+          this.applyPresenceEvent(event, message);
+          this.notifyListeners(event, message);
+        });
+      });
+    })().catch((error) => {
+      this.connectPromise = null;
+      throw error;
+    });
 
     return this.connectPromise;
   }
 
-  /**
-   * Disconnect from the realtime server
-   */
   disconnect(): void {
-    if (this.socket) {
-      this.socket.disconnect();
-      this.socket = null;
+    this.socket?.disconnect();
+    this.socket = null;
+    this.connectPromise = null;
+    for (const subscription of this.subscriptions.values()) {
+      this.settleSubscription(
+        subscription,
+        {
+          ok: false,
+          channel: this.getChannel(subscription),
+          error: { code: 'DISCONNECTED', message: 'Disconnected' },
+        },
+        false
+      );
     }
-    this.subscribedChannels.clear();
+    this.subscriptions.clear();
   }
 
-  /**
-   * Handle token changes (e.g., after auth refresh)
-   * Updates socket auth so reconnects use the new token
-   * If connected, triggers reconnect to apply new token immediately
-   */
-  private onTokenChange(): void {
-    const token = this.tokenManager.getAccessToken() ?? this.anonKey;
-
-    // Always update auth so socket.io auto-reconnect uses new token
-    if (this.socket) {
-      this.socket.auth = token ? { token } : {};
+  private reconnectForAuthChange(): void {
+    if (!this.socket) {
+      return;
     }
+    this.socket.disconnect();
+    this.socket.connect();
+  }
 
-    // Trigger reconnect if connected OR connecting (to avoid completing with stale token)
-    if (this.socket && (this.socket.connected || this.connectPromise)) {
-      this.socket.disconnect();
-      this.socket.connect();
-      // Note: on('connect') handler automatically re-subscribes to channels
+  private handleDisconnect(reason: string): void {
+    for (const subscription of this.subscriptions.values()) {
+      subscription.state = 'joining';
+      this.settleSubscription(
+        subscription,
+        {
+          ok: false,
+          channel: this.getChannel(subscription),
+          error: { code: 'DISCONNECTED', message: 'Connection lost before subscription completed' },
+        },
+        false
+      );
+    }
+    this.notifyListeners('disconnect', reason);
+  }
+
+  private getChannel(subscription: ChannelSubscription): string {
+    for (const [channel, candidate] of this.subscriptions) {
+      if (candidate === subscription) {
+        return channel;
+      }
+    }
+    return '';
+  }
+
+  private resubscribeChannels(): void {
+    for (const [channel, subscription] of this.subscriptions) {
+      this.requestSubscription(channel, subscription);
     }
   }
 
-  /**
-   * Check if connected to the realtime server
-   */
+  private requestSubscription(
+    channel: string,
+    subscription: ChannelSubscription
+  ): Promise<SubscribeResponse> {
+    if (subscription.pending) {
+      return subscription.pending;
+    }
+    const socket = this.socket;
+    if (!socket?.connected) {
+      return Promise.resolve({
+        ok: false,
+        channel,
+        error: { code: 'CONNECTION_FAILED', message: 'Not connected to realtime server' },
+      });
+    }
+
+    subscription.state = 'joining';
+    const epoch = ++subscription.epoch;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    subscription.pending = new Promise<SubscribeResponse>((resolve) => {
+      subscription.settlePending = (response) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        subscription.pending = undefined;
+        subscription.settlePending = undefined;
+        resolve(response);
+      };
+
+      timeoutId = setTimeout(() => {
+        if (this.subscriptions.get(channel) === subscription && subscription.epoch === epoch) {
+          this.settleSubscription(
+            subscription,
+            {
+              ok: false,
+              channel,
+              error: {
+                code: 'SUBSCRIBE_TIMEOUT',
+                message: 'Subscription acknowledgement timed out',
+              },
+            },
+            false
+          );
+        }
+      }, SUBSCRIBE_TIMEOUT);
+
+      socket.emit('realtime:subscribe', { channel }, (response: SubscribeResponse) => {
+        if (this.subscriptions.get(channel) !== subscription || subscription.epoch !== epoch) {
+          return;
+        }
+        if (response.ok) {
+          subscription.state = 'joined';
+          subscription.members = new Map(
+            response.presence.members.map((member) => [member.presenceId, member])
+          );
+        }
+        this.settleSubscription(subscription, response, false);
+      });
+    });
+    return subscription.pending;
+  }
+
+  private settleSubscription(
+    subscription: ChannelSubscription,
+    response: SubscribeResponse,
+    incrementEpoch: boolean
+  ): void {
+    if (incrementEpoch) {
+      subscription.epoch++;
+    }
+    subscription.settlePending?.(response);
+  }
+
+  private applyPresenceEvent(event: string, message: SocketMessage): void {
+    if (event !== 'presence:join' && event !== 'presence:leave') {
+      return;
+    }
+    const channel = message.meta?.channel;
+    const member = (message as SocketMessage & { member?: PresenceMember }).member;
+    if (!channel || !member) {
+      return;
+    }
+    const subscription = this.subscriptions.get(channel);
+    if (!subscription) {
+      return;
+    }
+    if (event === 'presence:join') {
+      subscription.members.set(member.presenceId, member);
+    } else {
+      subscription.members.delete(member.presenceId);
+    }
+  }
+
   get isConnected(): boolean {
     return this.socket?.connected ?? false;
   }
 
-  /**
-   * Get the current connection state
-   */
   get connectionState(): ConnectionState {
     if (!this.socket) {
       return 'disconnected';
     }
-    if (this.socket.connected) {
-      return 'connected';
-    }
-    return 'connecting';
+    return this.socket.connected ? 'connected' : 'connecting';
   }
 
-  /**
-   * Get the socket ID (if connected)
-   */
   get socketId(): string | undefined {
     return this.socket?.id;
   }
 
-  /**
-   * Subscribe to a channel
-   *
-   * Automatically connects if not already connected.
-   *
-   * @param channel - Channel name (e.g., 'orders:123', 'broadcast')
-   * @returns Promise with the subscription response
-   */
   async subscribe(channel: string): Promise<SubscribeResponse> {
-    // Already subscribed, return success
-    if (this.subscribedChannels.has(channel)) {
-      return { ok: true, channel, presence: { members: [] } };
+    let subscription = this.subscriptions.get(channel);
+    if (subscription) {
+      if (subscription.pending) {
+        return subscription.pending;
+      }
+      if (subscription.state === 'joined') {
+        return { ok: true, channel, presence: { members: [...subscription.members.values()] } };
+      }
+    } else {
+      subscription = { epoch: 0, state: 'joining', members: new Map() };
+      this.subscriptions.set(channel, subscription);
     }
 
-    // Auto-connect if not connected
     if (!this.socket?.connected) {
       try {
         await this.connect();
       } catch (error) {
+        if (this.subscriptions.get(channel) === subscription) {
+          this.subscriptions.delete(channel);
+        }
         const message = error instanceof Error ? error.message : 'Connection failed';
         return { ok: false, channel, error: { code: 'CONNECTION_FAILED', message } };
       }
     }
 
-    return new Promise((resolve) => {
-      this.socket!.emit('realtime:subscribe', { channel }, (response: SubscribeResponse) => {
-        if (response.ok) {
-          this.subscribedChannels.add(channel);
-        }
-        resolve(response);
-      });
-    });
+    return subscription.pending ?? this.requestSubscription(channel, subscription);
   }
 
-  /**
-   * Unsubscribe from a channel (fire-and-forget)
-   *
-   * @param channel - Channel name to unsubscribe from
-   */
   unsubscribe(channel: string): void {
-    this.subscribedChannels.delete(channel);
-
+    const subscription = this.subscriptions.get(channel);
+    if (!subscription) {
+      return;
+    }
+    this.subscriptions.delete(channel);
+    this.settleSubscription(
+      subscription,
+      {
+        ok: false,
+        channel,
+        error: { code: 'SUBSCRIPTION_CANCELLED', message: 'Subscription cancelled' },
+      },
+      true
+    );
     if (this.socket?.connected) {
       this.socket.emit('realtime:unsubscribe', { channel });
     }
   }
 
-  /**
-   * Publish a message to a channel
-   *
-   * @param channel - Channel name
-   * @param event - Event name
-   * @param payload - Message payload
-   */
   async publish<T = unknown>(channel: string, event: string, payload: T): Promise<void> {
     if (!this.socket?.connected) {
       throw new Error('Not connected to realtime server. Call connect() first.');
     }
-
-    this.socket!.emit('realtime:publish', { channel, event, payload });
+    this.socket.emit('realtime:publish', { channel, event, payload });
   }
 
-  /**
-   * Listen for events
-   *
-   * Reserved event names:
-   * - 'connect' - Fired when connected to the server
-   * - 'connect_error' - Fired when connection fails (payload: Error)
-   * - 'disconnect' - Fired when disconnected (payload: reason string)
-   * - 'error' - Fired when a realtime error occurs (payload: RealtimeErrorPayload)
-   *
-   * All other events receive a `SocketMessage` payload with metadata.
-   *
-   * @param event - Event name to listen for
-   * @param callback - Callback function when event is received
-   */
   on<T = SocketMessage>(event: string, callback: EventCallback<T>): void {
-    if (!this.eventListeners.has(event)) {
-      this.eventListeners.set(event, new Set());
-    }
-    this.eventListeners.get(event)!.add(callback as EventCallback);
+    const listeners = this.eventListeners.get(event) ?? new Set<EventCallback>();
+    listeners.add(callback as EventCallback);
+    this.eventListeners.set(event, listeners);
   }
 
-  /**
-   * Remove a listener for a specific event
-   *
-   * @param event - Event name
-   * @param callback - The callback function to remove
-   */
   off<T = SocketMessage>(event: string, callback: EventCallback<T>): void {
     const listeners = this.eventListeners.get(event);
-    if (listeners) {
-      listeners.delete(callback as EventCallback);
-      if (listeners.size === 0) {
-        this.eventListeners.delete(event);
-      }
+    listeners?.delete(callback as EventCallback);
+    if (listeners?.size === 0) {
+      this.eventListeners.delete(event);
     }
   }
 
-  /**
-   * Listen for an event only once, then automatically remove the listener
-   *
-   * @param event - Event name to listen for
-   * @param callback - Callback function when event is received
-   */
   once<T = SocketMessage>(event: string, callback: EventCallback<T>): void {
-    const wrapper: EventCallback<T> = (payload: T) => {
+    const wrapper: EventCallback<T> = (payload) => {
       this.off(event, wrapper);
       callback(payload);
     };
     this.on(event, wrapper);
   }
 
-  /**
-   * Get all currently subscribed channels
-   *
-   * @returns Array of channel names
-   */
   getSubscribedChannels(): string[] {
-    return Array.from(this.subscribedChannels);
+    return [...this.subscriptions.keys()];
+  }
+
+  getPresenceState(channel: string): PresenceMember[] {
+    return [...(this.subscriptions.get(channel)?.members.values() ?? [])];
   }
 }

--- a/src/modules/realtime.ts
+++ b/src/modules/realtime.ts
@@ -7,7 +7,7 @@ import type {
   SocketMessage,
   SubscribeResponse,
 } from '@insforge/shared-schemas';
-import { TokenManager } from '../lib/token-manager';
+import { AuthChangeEvent, TokenManager } from '../lib/token-manager';
 
 export type { PresenceMember, RealtimeErrorPayload, SocketMessage, SubscribeResponse };
 
@@ -54,7 +54,7 @@ export class Realtime {
       tokenManager.getAccessToken()
   ) {
     this.tokenManager.onAuthStateChange((event) => {
-      if (event !== 'tokenRefreshed') {
+      if (event !== AuthChangeEvent.TOKEN_REFRESHED) {
         this.reconnectForAuthChange();
       }
     });
@@ -244,7 +244,7 @@ export class Realtime {
           channel: subscription.channel,
           error: { code: 'DISCONNECTED', message: 'Connection lost before subscription completed' },
         },
-        false
+        true
       );
     }
     this.notifyListeners('disconnect', reason);

--- a/src/modules/realtime.ts
+++ b/src/modules/realtime.ts
@@ -1,6 +1,8 @@
 import type { Socket } from 'socket.io-client';
 import type {
   PresenceMember,
+  PresenceJoinMessage,
+  PresenceLeaveMessage,
   RealtimeErrorPayload,
   SocketMessage,
   SubscribeResponse,
@@ -15,11 +17,18 @@ export type EventCallback<T = unknown> = (payload: T) => void;
 type SubscriptionState = 'joining' | 'joined';
 
 interface ChannelSubscription {
+  channel: string;
   epoch: number;
   state: SubscriptionState;
   members: Map<string, PresenceMember>;
   pending?: Promise<SubscribeResponse>;
   settlePending?: (response: SubscribeResponse) => void;
+}
+
+interface ConnectionAttempt {
+  id: number;
+  socket: Socket;
+  cancel: (error: Error) => void;
 }
 
 const CONNECT_TIMEOUT = 10_000;
@@ -32,6 +41,8 @@ const SUBSCRIBE_TIMEOUT = 10_000;
 export class Realtime {
   private socket: Socket | null = null;
   private connectPromise: Promise<void> | null = null;
+  private connectionAttempt: ConnectionAttempt | null = null;
+  private nextConnectionAttemptId = 0;
   private subscriptions = new Map<string, ChannelSubscription>();
   private eventListeners = new Map<string, Set<EventCallback>>();
 
@@ -71,11 +82,15 @@ export class Realtime {
       return this.connectPromise;
     }
 
-    this.connectPromise = (async () => {
+    const attemptId = ++this.nextConnectionAttemptId;
+    const connection = (async () => {
       const { io } = await import('socket.io-client');
+      if (attemptId !== this.nextConnectionAttemptId) {
+        throw new Error('Connection cancelled');
+      }
 
       await new Promise<void>((resolve, reject) => {
-        this.socket = io(this.baseUrl, {
+        const socket = io(this.baseUrl, {
           transports: ['websocket'],
           auth: (callback) => {
             void this.getHandshakeToken().then(
@@ -84,18 +99,10 @@ export class Realtime {
             );
           },
         });
+        this.socket = socket;
 
         let initialConnection = true;
-        let timeoutId: ReturnType<typeof setTimeout> | null = setTimeout(() => {
-          if (!initialConnection) {
-            return;
-          }
-          initialConnection = false;
-          this.connectPromise = null;
-          this.socket?.disconnect();
-          this.socket = null;
-          reject(new Error(`Connection timeout after ${CONNECT_TIMEOUT}ms`));
-        }, CONNECT_TIMEOUT);
+        let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
         const clearConnectTimeout = () => {
           if (timeoutId) {
@@ -104,52 +111,96 @@ export class Realtime {
           }
         };
 
-        this.socket.on('connect', () => {
+        const dispose = () => {
+          clearConnectTimeout();
+          socket.off('connect', onConnect);
+          socket.off('connect_error', onConnectError);
+          socket.off('disconnect', onDisconnect);
+          socket.off('realtime:error', onRealtimeError);
+          socket.offAny(onAny);
+          socket.disconnect();
+          if (this.socket === socket) {
+            this.socket = null;
+          }
+          if (this.connectionAttempt?.id === attemptId) {
+            this.connectionAttempt = null;
+          }
+        };
+
+        const fail = (error: Error) => {
+          if (!initialConnection) {
+            return;
+          }
+          initialConnection = false;
+          dispose();
+          reject(error);
+        };
+
+        const onConnect = () => {
+          if (this.socket !== socket) {
+            return;
+          }
           clearConnectTimeout();
           this.resubscribeChannels();
           this.notifyListeners('connect');
           if (initialConnection) {
             initialConnection = false;
-            this.connectPromise = null;
+            if (this.connectionAttempt?.id === attemptId) {
+              this.connectionAttempt = null;
+            }
             resolve();
           }
-        });
+        };
 
-        this.socket.on('connect_error', (error: Error) => {
+        const onConnectError = (error: Error) => {
           clearConnectTimeout();
           this.notifyListeners('connect_error', error);
           if (initialConnection) {
-            initialConnection = false;
-            this.connectPromise = null;
-            reject(error);
+            fail(error);
           }
-        });
+        };
 
-        this.socket.on('disconnect', (reason: string) => {
+        const onDisconnect = (reason: string) => {
           this.handleDisconnect(reason);
-        });
+        };
 
-        this.socket.on('realtime:error', (error: RealtimeErrorPayload) => {
+        const onRealtimeError = (error: RealtimeErrorPayload) => {
           this.notifyListeners('error', error);
-        });
+        };
 
-        this.socket.onAny((event: string, message: SocketMessage) => {
+        const onAny = (event: string, message: SocketMessage) => {
           if (event === 'realtime:error') {
             return;
           }
           this.applyPresenceEvent(event, message);
           this.notifyListeners(event, message);
-        });
-      });
-    })().catch((error) => {
-      this.connectPromise = null;
-      throw error;
-    });
+        };
 
-    return this.connectPromise;
+        this.connectionAttempt = { id: attemptId, socket, cancel: fail };
+        socket.on('connect', onConnect);
+        socket.on('connect_error', onConnectError);
+        socket.on('disconnect', onDisconnect);
+        socket.on('realtime:error', onRealtimeError);
+        socket.onAny(onAny);
+        timeoutId = setTimeout(
+          () => fail(new Error(`Connection timeout after ${CONNECT_TIMEOUT}ms`)),
+          CONNECT_TIMEOUT
+        );
+      });
+    })();
+
+    const trackedConnection = connection.finally(() => {
+      if (this.connectPromise === trackedConnection) {
+        this.connectPromise = null;
+      }
+    });
+    this.connectPromise = trackedConnection;
+    return trackedConnection;
   }
 
   disconnect(): void {
+    this.nextConnectionAttemptId++;
+    this.connectionAttempt?.cancel(new Error('Disconnected'));
     this.socket?.disconnect();
     this.socket = null;
     this.connectPromise = null;
@@ -158,7 +209,7 @@ export class Realtime {
         subscription,
         {
           ok: false,
-          channel: this.getChannel(subscription),
+          channel: subscription.channel,
           error: { code: 'DISCONNECTED', message: 'Disconnected' },
         },
         false
@@ -182,22 +233,13 @@ export class Realtime {
         subscription,
         {
           ok: false,
-          channel: this.getChannel(subscription),
+          channel: subscription.channel,
           error: { code: 'DISCONNECTED', message: 'Connection lost before subscription completed' },
         },
         false
       );
     }
     this.notifyListeners('disconnect', reason);
-  }
-
-  private getChannel(subscription: ChannelSubscription): string {
-    for (const [channel, candidate] of this.subscriptions) {
-      if (candidate === subscription) {
-        return channel;
-      }
-    }
-    return '';
   }
 
   private resubscribeChannels(): void {
@@ -247,7 +289,7 @@ export class Realtime {
                 message: 'Subscription acknowledgement timed out',
               },
             },
-            false
+            true
           );
         }
       }, SUBSCRIBE_TIMEOUT);
@@ -283,8 +325,9 @@ export class Realtime {
     if (event !== 'presence:join' && event !== 'presence:leave') {
       return;
     }
-    const channel = message.meta?.channel;
-    const member = (message as SocketMessage & { member?: PresenceMember }).member;
+    const presenceEvent = message as PresenceJoinMessage | PresenceLeaveMessage;
+    const channel = presenceEvent.meta.channel;
+    const member = presenceEvent.member;
     if (!channel || !member) {
       return;
     }
@@ -324,7 +367,7 @@ export class Realtime {
         return { ok: true, channel, presence: { members: [...subscription.members.values()] } };
       }
     } else {
-      subscription = { epoch: 0, state: 'joining', members: new Map() };
+      subscription = { channel, epoch: 0, state: 'joining', members: new Map() };
       this.subscriptions.set(channel, subscription);
     }
 

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -162,7 +162,7 @@ export function createBrowserClient(
       }
 
       accessToken = refreshBody.accessToken;
-      client?.setAccessToken(refreshBody.accessToken);
+      client?.setAccessToken(refreshBody.accessToken, 'tokenRefreshed');
       return refreshBody as AuthRefreshResponse;
     })().finally(() => {
       sessionChecked = true;
@@ -224,9 +224,9 @@ export function createBrowserClient(
     },
   });
   const setAccessToken = client.setAccessToken.bind(client);
-  client.setAccessToken = (token: string | null) => {
+  client.setAccessToken = (token: string | null, event) => {
     accessToken = token;
-    setAccessToken(token);
+    setAccessToken(token, event);
   };
 
   if (accessToken) {

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -1,4 +1,5 @@
 import { InsForgeClient } from '../client';
+import { AuthChangeEvent } from '../lib/token-manager';
 import { InsForgeError, type AuthRefreshResponse, type InsForgeConfig } from '../types';
 import { isJwtExpiredOrExpiring } from '../lib/jwt';
 import { ERROR_CODES } from '@insforge/shared-schemas';
@@ -162,7 +163,7 @@ export function createBrowserClient(
       }
 
       accessToken = refreshBody.accessToken;
-      client?.setAccessToken(refreshBody.accessToken, 'tokenRefreshed');
+      client?.setAccessToken(refreshBody.accessToken, AuthChangeEvent.TOKEN_REFRESHED);
       return refreshBody as AuthRefreshResponse;
     })().finally(() => {
       sessionChecked = true;


### PR DESCRIPTION
## Summary
- use a handshake-time token provider; token refresh does not disconnect an established socket
- refresh near-expiry browser tokens before a new handshake and expose typed auth-state events
- model each channel as a subscription record that retries after reconnect, uses subscribe acknowledgements, and ignores stale acknowledgements
- track presence snapshots and remove the obsolete in-band realtime:auth protocol in the paired backend PR: https://github.com/InsForge/InsForge/pull/1653

## Verification
- npm run test:run (181 tests)
- npm run format:check
- npm run lint
- npm run typecheck
- npm run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves realtime presence across reconnects and makes auth updates handshake-safe so token refreshes don’t drop live sockets. Adds acked subscriptions with timeouts/retries and typed auth events for clearer client control.

- **New Features**
  - Handshake-time token provider for `socket.io-client` via `HttpClient.getValidAccessToken()`; refresh near-expiry browser tokens before a new connection.
  - Typed auth events `'signedIn' | 'signedOut' | 'tokenRefreshed'`; exported `AuthChangeEvent`/`AuthStateChangeCallback`; `auth.onAuthStateChange(...)`; `InsForgeClient.setAccessToken(token, event)` to mark refresh vs sign-in; `TokenManager` is now internal to the SDK.
  - Realtime subscriptions now use acks with timeout, retry pending subscriptions after reconnect, pause rejected ones until an auth boundary or explicit retry; `realtime.getPresenceState(channel)` returns the current member list.

- **Bug Fixes**
  - Presence is preserved across reconnects with snapshot replacement on rejoin; late/stale subscribe acks are ignored (after disconnect, timeout, or unsubscribe).
  - Token refresh no longer disconnects an active socket; reconnects only on sign-in/sign-out; handshakes always read the latest token.
  - Hardened connect lifecycle: cancel stale attempts, enforce connect timeouts, dispose failed sockets; in-flight subscriptions settle on disconnect; guarded refresh races keep newer sessions and only clear invalid ones when the rejected refresh matches the current token.

<sup>Written for commit 317c107922b5250bd454d396195582b4b68c23b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unsubscribe-capable auth state-change event system (signed in, token refreshed, signed out).
  * Exposed new auth event types to the SDK entry point.
  * Added handshake-friendly `getValidAccessToken` for realtime authentication.
  * Added realtime presence state access via `getPresenceState(channel)`.

* **Bug Fixes**
  * Realtime handshakes now use the most up-to-date valid token.
  * Token refresh flows now persist with a distinct “tokenRefreshed” reason and clear session state on auth failures.

* **Chores / Tests**
  * Updated and expanded auth, HTTP token refresh, and realtime lifecycle tests.
  * Bumped package version to 1.4.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve presence state across reconnects in the Realtime module
> - Refactors [`Realtime`](https://github.com/InsForge/InsForge-sdk-js/pull/101/files#diff-0f32ac4a7e57737f8d89d18f91d3a79422bb86cd84d72213d4ecdec76fdf25fe) to track subscriptions with acknowledgements, timeouts, and epoch checks, preventing late acks from reviving cancelled subscriptions and replacing presence snapshots on reconnect.
> - Adds `getValidAccessToken()` to [`HttpClient`](https://github.com/InsForge/InsForge-sdk-js/pull/101/files#diff-c15a8f720fb13adf8a92b21adb9ad29c2169a8ffea3df727a03a5728ca164e96) to proactively refresh expiring tokens; each handshake now supplies a fresh token via a callback rather than a static value.
> - Replaces the single `onTokenChange` callback in [`TokenManager`](https://github.com/InsForge/InsForge-sdk-js/pull/101/files#diff-d983e2f26952b736c6324d55b770fe96ac0a04a3e4837011e7251d24edc94d41) with a multi-subscriber `onAuthStateChange` mechanism emitting `'signedIn'`, `'signedOut'`, or `'tokenRefreshed'` events.
> - `Realtime` reconnects on auth state changes but skips reconnect for `'tokenRefreshed'` events, avoiding unnecessary disconnections on token rotation.
> - Behavioral Change: `refreshAndSaveSession` now emits `'tokenRefreshed'` instead of `'signedIn'`; consumers using `onAuthStateChange` must handle the new event type.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #101 opened
>
> - Introduced `AccessTokenChangeEvent` type to distinguish between sign-in and token refresh events [f43a97f]
> - Rewrote `Realtime.connect` method to support cancellation of stale or concurrent connection attempts [f43a97f]
> - Updated `Realtime.disconnect` and `Realtime.handleDisconnect` methods to properly cancel in-flight connection attempts and populate channel information in subscription errors [f43a97f]
> - Modified `Realtime.requestSubscription` to ignore late subscription acknowledgements that arrive after timeout [f43a97f]
> - Refactored `Realtime.applyPresenceEvent` to use typed presence message structures [f43a97f]
> - Added error handling to `HttpClient.getValidAccessToken` to clear auth session on unauthorized refresh attempts [f43a97f]
> - Updated `TokenManager.notifyAuthStateChange` to isolate throwing listeners and continue notifying subsequent listeners [f43a97f]
> - Added and updated tests to validate token refresh event handling, connection cancellation, subscription timeout behavior, presence updates, and error isolation [f43a97f]
> - Modified `HttpClient.getValidAccessToken` to conditionally preserve sessions during token refresh failures [0a83de4]
> - Modified `Realtime.applyPresenceEvent` to handle presence events missing metadata [0a83de4]
> - Replaced subscription state model in `realtime` module from two states to three-state status system and updated subscription request handling to transition between statuses based on server acknowledgment [dbd1a24]
> - Modified reconnection and disconnection handling in `realtime` module to preserve rejected subscriptions across regular reconnects and reset them only before authentication-triggered reconnects [dbd1a24]
> - Updated public API methods in `realtime` module to reflect subscription status in their return values and behavior [dbd1a24]
> - Added test coverage in `realtime.test.ts` for subscription status behavior including server rejection handling and reconnection scenarios [dbd1a24]
> - Changed `Realtime.onDisconnect` to settle pending channel subscriptions with a flag that ignores stale acknowledgements received after disconnect, preventing them from being treated as successful until an explicit resubscribe occurs [5f01275]
> - Introduced `AuthChangeEvent` as a runtime constant object and replaced all string literal event values with references to the constants across authentication and realtime modules [5f01275]
> - Added test coverage verifying that realtime subscription acknowledgements received after disconnect are properly ignored before resubscribing [5f01275]
> - Bumped package version from 1.4.3 to 1.4.4 [5f01275]
> - Removed `TokenManager` from the public API exports of the package entrypoint and added test coverage to verify `TokenManager` is not exposed in the SDK namespace [317c107]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21513fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->