### PR TITLE
feat(storage): add removeMany for batch object deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,11 +214,11 @@ const { data, error } = await insforge.storage.from('avatars').download('user-av
 // Delete a file
 const { data, error } = await insforge.storage.from('avatars').remove('user-avatar.png');
 
-// Delete multiple files (auto-batched, any number of keys)
+// Delete multiple files (maximum 1000 keys)
 const { data, error } = await insforge.storage
   .from('avatars')
-  .removeMany(['user-avatar.png', 'old-avatar.png']);
-// data: { success: string[], failures: { key, error }[] }
+  .remove(['user-avatar.png', 'old-avatar.png']);
+// data: { results: [{ key, status: 'deleted' | 'notFound' | 'failed', message? }] }
 
 // List files
 const { data, error } = await insforge.storage.from('avatars').list();

--- a/README.md
+++ b/README.md
@@ -212,7 +212,13 @@ const { data, error } = await insforge.storage.from('avatars').upload(file);
 const { data, error } = await insforge.storage.from('avatars').download('user-avatar.png');
 
 // Delete a file
-const { data, error } = await insforge.storage.from('avatars').remove(['user-avatar.png']);
+const { data, error } = await insforge.storage.from('avatars').remove('user-avatar.png');
+
+// Delete multiple files (auto-batched, any number of keys)
+const { data, error } = await insforge.storage
+  .from('avatars')
+  .removeMany(['user-avatar.png', 'old-avatar.png']);
+// data: { success: string[], failures: { key, error }[] }
 
 // List files
 const { data, error } = await insforge.storage.from('avatars').list();

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -746,6 +746,16 @@ await bucket.remove('path/file.jpg');
 // Response: { data: { message }, error }
 ```
 
+### `bucket.removeMany()`
+
+```javascript
+await bucket.removeMany(['path/a.jpg', 'path/b.txt']); // any number of keys
+// Response: { data: { success, failures }, error }
+// success:  string[] — keys that were deleted
+// failures: { key, error }[] — each remaining key with the reason it wasn't deleted
+// Keys are auto-batched (max 1000 per request); each key resolves independently.
+```
+
 ### `bucket.getPublicUrl()`
 
 ```javascript

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -742,18 +742,14 @@ await bucket.list({ prefix: 'users/', limit: 10 });
 ### `bucket.remove()`
 
 ```javascript
+// Delete one object
 await bucket.remove('path/file.jpg');
 // Response: { data: { message }, error }
-```
 
-### `bucket.removeMany()`
-
-```javascript
-await bucket.removeMany(['path/a.jpg', 'path/b.txt']); // any number of keys
-// Response: { data: { success, failures }, error }
-// success:  string[] — keys that were deleted
-// failures: { key, error }[] — each remaining key with the reason it wasn't deleted
-// Keys are auto-batched (max 1000 per request); each key resolves independently.
+// Delete multiple objects in one request (maximum 1000 keys)
+await bucket.remove(['path/a.jpg', 'path/b.txt']);
+// Response: { data: { results }, error }
+// results: { key, status: 'deleted' | 'notFound' | 'failed', message? }[]
 ```
 
 ### `bucket.getPublicUrl()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@insforge/shared-schemas": "^1.1.58",
+        "@insforge/shared-schemas": "^1.2.0",
         "@supabase/postgrest-js": "^1.21.3",
         "socket.io-client": "^4.8.1"
       },
@@ -785,9 +785,7 @@
       }
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.1.58",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.1.58.tgz",
-      "integrity": "sha512-of494/PttH+nf5SBz63mAtgCBimDPIDF/tPEYb9zMNOySsGYNXYXWyqcyPuxnQcVuThlV5cdUwxW3cImvXyAvw==",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -786,6 +786,8 @@
     },
     "node_modules/@insforge/shared-schemas": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.2.0.tgz",
+      "integrity": "sha512-qUYNXkCKVPTKXC/jWtG+FEgH/NFY0d2EnEgjYj8vu+R6wezGpKXP8T0rSMtoavgXo1ZcOTCR8+pQJBWJSR9BvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "url": "https://github.com/InsForge/insforge-sdk-js/issues"
   },
   "dependencies": {
-    "@insforge/shared-schemas": "^1.1.58",
+    "@insforge/shared-schemas": "^1.2.0",
     "@supabase/postgrest-js": "^1.21.3",
     "socket.io-client": "^4.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.type-tests.json",
     "publish:dev": "npm version prerelease --preid=dev && npm run build && npm publish --tag dev",
     "publish:stable": "npm run build && npm publish"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
   CreateUserRequest,
   CreateSessionRequest,
   AuthErrorResponse,
+  DeleteObjectResult,
   DeleteObjectsResponse,
 } from '@insforge/shared-schemas';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,12 @@ export { Database } from './modules/database-postgrest';
 
 // Re-export storage module and types
 export { Storage, StorageBucket } from './modules/storage';
-export type { StorageResponse } from './modules/storage';
+export type {
+  StorageResponse,
+  RemoveManyResult,
+  RemoveManyResponse,
+  RemoveManyOutcome,
+} from './modules/storage';
 
 // Re-export AI module
 export { AI } from './modules/ai';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
   CreateUserRequest,
   CreateSessionRequest,
   AuthErrorResponse,
+  DeleteObjectsResponse,
 } from '@insforge/shared-schemas';
 
 // Re-export auth module for advanced usage
@@ -36,12 +37,7 @@ export { Database } from './modules/database-postgrest';
 
 // Re-export storage module and types
 export { Storage, StorageBucket } from './modules/storage';
-export type {
-  StorageResponse,
-  RemoveManyResult,
-  RemoveManyResponse,
-  RemoveManyOutcome,
-} from './modules/storage';
+export type { StorageResponse } from './modules/storage';
 
 // Re-export AI module
 export { AI } from './modules/ai';

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -3,6 +3,7 @@ import { StorageBucket } from '../storage';
 import { HttpClient } from '../../lib/http-client';
 import { InsForgeError } from '../../types';
 import { TokenManager } from '../../lib/token-manager';
+import type { DeleteObjectsResponse } from '@insforge/shared-schemas';
 
 function makeTokenManager(): TokenManager {
   return {
@@ -201,7 +202,7 @@ describe('StorageBucket.remove', () => {
         { key: 'missing.pdf', status: 'notFound' },
         { key: 'locked.pdf', status: 'failed', message: 'Delete denied' },
       ],
-    } as const;
+    } satisfies DeleteObjectsResponse;
     const fetchFn = vi.fn().mockResolvedValue(jsonRes(200, response));
     const bucket = new StorageBucket('docs', makeHttp(fetchFn));
 

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -174,3 +174,89 @@ describe('StorageBucket.createSignedUrls', () => {
     expect(new URL(String(fetchFn.mock.calls[0][0])).searchParams.get('expiresIn')).toBe('60');
   });
 });
+
+describe('StorageBucket.remove', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deletes a single path with the single-object endpoint', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonRes(200, { message: 'Object deleted' }));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.remove('files/old report.pdf');
+
+    expect(result).toEqual({ data: { message: 'Object deleted' }, error: null });
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(new URL(String(fetchFn.mock.calls[0][0])).pathname).toBe(
+      '/api/storage/buckets/docs/objects/files%2Fold%20report.pdf'
+    );
+    expect(fetchFn.mock.calls[0][1]?.method).toBe('DELETE');
+  });
+
+  it('deletes multiple paths in one request and returns the server results unchanged', async () => {
+    const response = {
+      results: [
+        { key: 'a.pdf', status: 'deleted' },
+        { key: 'missing.pdf', status: 'notFound' },
+        { key: 'locked.pdf', status: 'failed', message: 'Delete denied' },
+      ],
+    } as const;
+    const fetchFn = vi.fn().mockResolvedValue(jsonRes(200, response));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.remove(['a.pdf', 'missing.pdf', 'locked.pdf']);
+
+    expect(result).toEqual({ data: response, error: null });
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(new URL(String(fetchFn.mock.calls[0][0])).pathname).toBe(
+      '/api/storage/buckets/docs/objects'
+    );
+    expect(fetchFn.mock.calls[0][1]?.method).toBe('DELETE');
+    expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({
+      keys: ['a.pdf', 'missing.pdf', 'locked.pdf'],
+    });
+  });
+
+  it('surfaces a batch request error through the storage response envelope', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        jsonRes(
+          400,
+          { error: 'STORAGE_ERROR', message: 'At least one object key is required' },
+          'Bad Request'
+        )
+      );
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.remove([]);
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBeInstanceOf(InsForgeError);
+    expect(result.error?.statusCode).toBe(400);
+    expect(result.error?.message).toBe('At least one object key is required');
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it('does not split arrays that exceed the server limit into multiple requests', async () => {
+    const paths = Array.from({ length: 1001 }, (_, index) => `file-${index}.txt`);
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        jsonRes(
+          400,
+          { error: 'STORAGE_ERROR', message: 'Cannot delete more than 1000 objects at once' },
+          'Bad Request'
+        )
+      );
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.remove(paths);
+
+    expect(result.data).toBeNull();
+    expect(result.error?.statusCode).toBe(400);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body)).keys).toHaveLength(1001);
+  });
+});

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { StorageBucket } from '../storage';
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vitest';
+import { StorageBucket, type StorageResponse } from '../storage';
 import { HttpClient } from '../../lib/http-client';
 import { InsForgeError } from '../../types';
 import { TokenManager } from '../../lib/token-manager';
@@ -179,6 +179,15 @@ describe('StorageBucket.createSignedUrls', () => {
 describe('StorageBucket.remove', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('accepts a union-typed target', () => {
+    const bucket = new StorageBucket('docs', makeHttp(vi.fn()));
+    const remove = (target: string | string[]) => bucket.remove(target);
+
+    expectTypeOf(remove).returns.toEqualTypeOf<
+      Promise<StorageResponse<{ message: string } | DeleteObjectsResponse>>
+    >();
   });
 
   it('deletes a single path with the single-object endpoint', async () => {

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -539,10 +539,9 @@ export class StorageBucket {
 
       const settled = await Promise.allSettled(
         batches.map((keys) =>
-          this.http.delete<RemoveManyResponse>(
-            `/api/storage/buckets/${encodeURIComponent(this.bucketName)}/objects`,
-            { body: { keys } }
-          )
+          this.http.delete<RemoveManyResponse>(`/api/storage/buckets/${this.bucketName}/objects`, {
+            body: { keys },
+          })
         )
       );
 

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -29,6 +29,35 @@ interface DownloadStrategy {
 }
 
 /**
+ * Max object keys accepted per batch-delete request. Requests with more keys are
+ * split into multiple requests client-side. Mirrors the server-side limit.
+ */
+const DELETE_OBJECTS_MAX_KEYS = 1000;
+
+/** Result for a single key in the raw batch-delete HTTP response. */
+export interface RemoveManyResult {
+  key: string;
+  status: 'deleted' | 'notFound' | 'failed';
+  /** Present only when `status` is `'failed'`. */
+  message?: string;
+}
+
+/** Raw batch-delete HTTP response body: one entry per requested (deduped) key. */
+export interface RemoveManyResponse {
+  results: RemoveManyResult[];
+}
+
+/**
+ * Aggregated outcome of {@link StorageBucket.removeMany} across all batches.
+ * `success` holds the keys that were deleted; `failures` pairs each remaining
+ * key with the reason it wasn't (not found, delete failed, or a request error).
+ */
+export interface RemoveManyOutcome {
+  success: string[];
+  failures: { key: string; error: Error }[];
+}
+
+/**
  * Storage bucket operations
  */
 export class StorageBucket {
@@ -473,6 +502,85 @@ export class StorageBucket {
       );
 
       return { data: response, error: null };
+    } catch (error) {
+      return {
+        data: null,
+        error:
+          error instanceof InsForgeError
+            ? error
+            : new InsForgeError('Delete failed', 500, 'STORAGE_ERROR'),
+      };
+    }
+  }
+
+  /**
+   * Delete multiple files.
+   *
+   * Keys are split into batches of at most {@link DELETE_OBJECTS_MAX_KEYS} and
+   * sent concurrently, so there is no client-side cap on how many keys you pass.
+   * Each key resolves independently: a missing key or a failed request does not
+   * prevent the others from being deleted. The result aggregates every batch into
+   * `success` (deleted keys) and `failures` (each remaining key with its reason).
+   *
+   * @param paths - The object keys/paths (any length; deduped server-side per batch)
+   * @returns `{ data: { success, failures }, error }`. `error` is non-null only
+   *   for an unexpected top-level failure; per-key problems surface in `failures`.
+   */
+  async removeMany(paths: string[]): Promise<StorageResponse<RemoveManyOutcome>> {
+    try {
+      if (paths.length === 0) {
+        return { data: { success: [], failures: [] }, error: null };
+      }
+
+      const batches: string[][] = [];
+      for (let index = 0; index < paths.length; index += DELETE_OBJECTS_MAX_KEYS) {
+        batches.push(paths.slice(index, index + DELETE_OBJECTS_MAX_KEYS));
+      }
+
+      const settled = await Promise.allSettled(
+        batches.map((keys) =>
+          this.http.delete<RemoveManyResponse>(
+            `/api/storage/buckets/${encodeURIComponent(this.bucketName)}/objects`,
+            { body: { keys } }
+          )
+        )
+      );
+
+      const success: string[] = [];
+      const failures: { key: string; error: Error }[] = [];
+
+      settled.forEach((result, index) => {
+        const keys = batches[index];
+
+        // A rejected batch fails the whole slice of keys with the same reason.
+        if (result.status === 'rejected') {
+          const error =
+            result.reason instanceof Error
+              ? result.reason
+              : new InsForgeError(String(result.reason), 500, 'STORAGE_ERROR');
+          keys.forEach((key) => failures.push({ key, error }));
+          return;
+        }
+
+        result.value.results.forEach((deleteResult) => {
+          if (deleteResult.status === 'deleted') {
+            success.push(deleteResult.key);
+            return;
+          }
+          failures.push({
+            key: deleteResult.key,
+            error: new InsForgeError(
+              deleteResult.status === 'notFound'
+                ? 'Object not found'
+                : (deleteResult.message ?? 'Failed to delete object'),
+              deleteResult.status === 'notFound' ? 404 : 500,
+              'STORAGE_ERROR'
+            ),
+          });
+        });
+      });
+
+      return { data: { success, failures }, error: null };
     } catch (error) {
       return {
         data: null,

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -472,6 +472,11 @@ export class StorageBucket {
   /** Delete multiple files in a single request. */
   async remove(paths: string[]): Promise<StorageResponse<DeleteObjectsResponse>>;
 
+  /** Delete one or more files when the input type is not narrowed. */
+  async remove(
+    pathOrPaths: string | string[]
+  ): Promise<StorageResponse<{ message: string } | DeleteObjectsResponse>>;
+
   /**
    * Delete one or more files.
    *

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -5,7 +5,11 @@
 
 import { HttpClient } from '../lib/http-client';
 import { InsForgeError } from '../types';
-import type { StorageFileSchema, ListObjectsResponseSchema } from '@insforge/shared-schemas';
+import type {
+  StorageFileSchema,
+  ListObjectsResponseSchema,
+  DeleteObjectsResponse,
+} from '@insforge/shared-schemas';
 
 export interface StorageResponse<T> {
   data: T | null;
@@ -26,35 +30,6 @@ interface DownloadStrategy {
   method: 'direct' | 'presigned';
   url: string;
   expiresAt?: Date;
-}
-
-/**
- * Max object keys accepted per batch-delete request. Requests with more keys are
- * split into multiple requests client-side. Mirrors the server-side limit.
- */
-const DELETE_OBJECTS_MAX_KEYS = 1000;
-
-/** Result for a single key in the raw batch-delete HTTP response. */
-export interface RemoveManyResult {
-  key: string;
-  status: 'deleted' | 'notFound' | 'failed';
-  /** Present only when `status` is `'failed'`. */
-  message?: string;
-}
-
-/** Raw batch-delete HTTP response body: one entry per requested (deduped) key. */
-export interface RemoveManyResponse {
-  results: RemoveManyResult[];
-}
-
-/**
- * Aggregated outcome of {@link StorageBucket.removeMany} across all batches.
- * `success` holds the keys that were deleted; `failures` pairs each remaining
- * key with the reason it wasn't (not found, delete failed, or a request error).
- */
-export interface RemoveManyOutcome {
-  success: string[];
-  failures: { key: string; error: Error }[];
 }
 
 /**
@@ -491,95 +466,34 @@ export class StorageBucket {
     }
   }
 
+  /** Delete a single file. */
+  async remove(path: string): Promise<StorageResponse<{ message: string }>>;
+
+  /** Delete multiple files in a single request. */
+  async remove(paths: string[]): Promise<StorageResponse<DeleteObjectsResponse>>;
+
   /**
-   * Delete a file
-   * @param path - The object key/path
+   * Delete one or more files.
+   *
+   * A string uses the single-object endpoint. An array uses the batch endpoint,
+   * which accepts at most 1000 keys and returns one result per key.
+   *
+   * @param pathOrPaths - One object key/path or an array of object keys/paths
    */
-  async remove(path: string): Promise<StorageResponse<{ message: string }>> {
+  async remove(
+    pathOrPaths: string | string[]
+  ): Promise<StorageResponse<{ message: string } | DeleteObjectsResponse>> {
     try {
-      const response = await this.http.delete<{ message: string }>(
-        `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}`
-      );
+      const response = Array.isArray(pathOrPaths)
+        ? await this.http.delete<DeleteObjectsResponse>(
+            `/api/storage/buckets/${this.bucketName}/objects`,
+            { body: { keys: pathOrPaths } }
+          )
+        : await this.http.delete<{ message: string }>(
+            `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(pathOrPaths)}`
+          );
 
       return { data: response, error: null };
-    } catch (error) {
-      return {
-        data: null,
-        error:
-          error instanceof InsForgeError
-            ? error
-            : new InsForgeError('Delete failed', 500, 'STORAGE_ERROR'),
-      };
-    }
-  }
-
-  /**
-   * Delete multiple files.
-   *
-   * Keys are split into batches of at most {@link DELETE_OBJECTS_MAX_KEYS} and
-   * sent concurrently, so there is no client-side cap on how many keys you pass.
-   * Each key resolves independently: a missing key or a failed request does not
-   * prevent the others from being deleted. The result aggregates every batch into
-   * `success` (deleted keys) and `failures` (each remaining key with its reason).
-   *
-   * @param paths - The object keys/paths (any length; deduped server-side per batch)
-   * @returns `{ data: { success, failures }, error }`. `error` is non-null only
-   *   for an unexpected top-level failure; per-key problems surface in `failures`.
-   */
-  async removeMany(paths: string[]): Promise<StorageResponse<RemoveManyOutcome>> {
-    try {
-      if (paths.length === 0) {
-        return { data: { success: [], failures: [] }, error: null };
-      }
-
-      const batches: string[][] = [];
-      for (let index = 0; index < paths.length; index += DELETE_OBJECTS_MAX_KEYS) {
-        batches.push(paths.slice(index, index + DELETE_OBJECTS_MAX_KEYS));
-      }
-
-      const settled = await Promise.allSettled(
-        batches.map((keys) =>
-          this.http.delete<RemoveManyResponse>(`/api/storage/buckets/${this.bucketName}/objects`, {
-            body: { keys },
-          })
-        )
-      );
-
-      const success: string[] = [];
-      const failures: { key: string; error: Error }[] = [];
-
-      settled.forEach((result, index) => {
-        const keys = batches[index];
-
-        // A rejected batch fails the whole slice of keys with the same reason.
-        if (result.status === 'rejected') {
-          const error =
-            result.reason instanceof Error
-              ? result.reason
-              : new InsForgeError(String(result.reason), 500, 'STORAGE_ERROR');
-          keys.forEach((key) => failures.push({ key, error }));
-          return;
-        }
-
-        result.value.results.forEach((deleteResult) => {
-          if (deleteResult.status === 'deleted') {
-            success.push(deleteResult.key);
-            return;
-          }
-          failures.push({
-            key: deleteResult.key,
-            error: new InsForgeError(
-              deleteResult.status === 'notFound'
-                ? 'Object not found'
-                : (deleteResult.message ?? 'Failed to delete object'),
-              deleteResult.status === 'notFound' ? 404 : 500,
-              'STORAGE_ERROR'
-            ),
-          });
-        });
-      });
-
-      return { data: { success, failures }, error: null };
     } catch (error) {
       return {
         data: null,

--- a/tsconfig.type-tests.json
+++ b/tsconfig.type-tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/modules/__tests__/storage.test.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
Closes #58 

## Summary

Adds `StorageBucket.removeMany()` for deleting multiple objects in one call, and fixes the README's incorrect `remove()` usage.

Backs the new `DELETE /api/storage/buckets/:bucketName/objects` endpoint (body `{ keys: [...] }`) from https://github.com/InsForge/InsForge/pull/1627, which returns a per-key result of `deleted | notFound | failed`.

## Changes

- **`removeMany(paths)`** — splits keys into batches of 1000 as there's a request cap of 1000 keys and deletes them concurrently via `Promise.allSettled`, so there's no client-side cap on how many keys you pass. Mirrors the dashboard's `deleteObjects` implementation.
- **Types** — added `RemoveManyResult`, `RemoveManyResponse` (raw HTTP body), and `RemoveManyOutcome` (aggregated result), re-exported from the package root.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add batch deletion by overloading `StorageBucket.remove()` to accept a single key or an array. Returns per-key results for arrays, updates docs, and exports delete result types.

- **New Features**
  - `remove('key')` uses `DELETE /api/storage/buckets/{bucket}/objects/{encodedPath}`; `remove(['a', 'b'])` uses `DELETE /api/storage/buckets/{bucket}/objects` with `{ keys }`.
  - Batch response: `{ data: { results: [{ key, status: 'deleted' | 'notFound' | 'failed', message? }] }, error }`.
  - No client-side batching; server limit is 1000 keys per request (arrays over 1000 will error).
  - Re-export `DeleteObjectResult` and `DeleteObjectsResponse`; README and SDK reference updated.

- **Dependencies**
  - Bump `@insforge/shared-schemas` to `^1.2.0`.

<sup>Written for commit 6d847ef70d8a4bd91920a8f5d7a11982f4f26baf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add batch object deletion to `StorageBucket.remove`
> - `StorageBucket.remove` now accepts either a single path string or an array of path strings; single deletes hit `/objects/{key}` and return `{ message }`, while batch deletes hit `/objects` with `{ keys: string[] }` and return per-key results.
> - Overloads are typed so callers get narrowed return types based on input shape; `DeleteObjectResult` and `DeleteObjectsResponse` are re-exported from the SDK entry point.
> - The server enforces a 1000-key limit per batch request; the SDK sends arrays as-is and surfaces the server error if exceeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df3f957.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended storage deletion to support multi-object deletes via `remove([...])`, returning per-key outcomes (`deleted`, `notFound`, `failed`).
* **Documentation**
  * Updated README and storage reference docs with single-file and multi-file delete examples, including batch limits and detailed `results` response shape.
* **Bug Fixes**
  * Ensures batch deletion sends a single request for provided key arrays (no client-side splitting).
* **Tests**
  * Added type and behavior coverage for single vs batch deletion requests and error handling.
* **Chores**
  * Added a `typecheck` script and refreshed shared delete response schema types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->