### PR TITLE
ci: publish npm releases with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,86 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event_name == 'release' || contains(github.ref_name, '-')
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate release channel and version
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease || false }}
+        run: |
+          node <<'NODE'
+          const { appendFileSync, readFileSync } = require('node:fs');
+
+          const packageVersion = JSON.parse(readFileSync('package.json', 'utf8')).version;
+          const tag = process.env.RELEASE_TAG;
+          const eventName = process.env.EVENT_NAME;
+          let distTag;
+
+          if (eventName === 'release') {
+            if (process.env.RELEASE_IS_PRERELEASE === 'true') {
+              throw new Error('GitHub Releases may only publish stable versions');
+            }
+            if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
+              throw new Error(`Stable release tag must match vX.Y.Z; received ${tag}`);
+            }
+            distTag = 'latest';
+          } else if (eventName === 'push') {
+            const match = tag.match(/^v\d+\.\d+\.\d+-(alpha|beta|rc)\.\d+$/);
+            if (!match) {
+              throw new Error(
+                `Prerelease tag must match vX.Y.Z-(alpha|beta|rc).N; received ${tag}`,
+              );
+            }
+            distTag = match[1];
+          } else {
+            throw new Error(`Unsupported publish event: ${eventName}`);
+          }
+
+          const tagVersion = tag.slice(1);
+          if (tagVersion !== packageVersion) {
+            throw new Error(
+              `Tag version ${tagVersion} does not match package.json version ${packageVersion}`,
+            );
+          }
+
+          appendFileSync(process.env.GITHUB_OUTPUT, `dist_tag=${distTag}\n`);
+          console.log(`Validated @insforge/sdk@${packageVersion} for npm tag ${distTag}`);
+          NODE
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run test:run
+      - run: npm run build
+      - run: npm pack --dry-run
+
+      - name: Publish package
+        run: npm publish --access public --tag "${{ steps.release.outputs.dist_tag }}"


### PR DESCRIPTION
## Summary

- publish stable GitHub Releases to the npm `latest` dist-tag
- publish `alpha`, `beta`, and `rc` Git tags to matching npm dist-tags
- reject GitHub prereleases, unsupported channels, and tag/package version mismatches
- authenticate with npm Trusted Publishing through OIDC instead of a long-lived token

## Impact

Maintainers can publish `@insforge/sdk` by creating a stable GitHub Release or pushing a supported prerelease tag. The publish job uses the GitHub `npm` environment, Node.js 24, minimal permissions, and npm's automatic provenance.

Before the first release, configure the `@insforge/sdk` Trusted Publisher on npm with:

- Publisher: GitHub Actions
- Organization: `InsForge`
- Repository: `InsForge-sdk-js`
- Workflow filename: `publish.yml`
- Environment name: `npm`
- Allowed action: `npm publish`

## Validation

- `npm run format:check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run typecheck`
- `npm run test:run` (193 tests passed)
- `npm run build`
- `npm pack --dry-run`
- YAML/OIDC configuration validation
- stable, beta, mismatch, GitHub prerelease, unsupported-channel, and stable-tag-skip cases


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to publish `@insforge/sdk` to npm with Trusted Publishing (OIDC) and automatic dist‑tag mapping. Maintainers can release via a stable GitHub Release or supported prerelease tags, with strict tag/version checks.

- **New Features**
  - Stable GitHub Releases publish to npm `latest`; `alpha`, `beta`, and `rc` tags map to matching dist-tags.
  - Blocks GitHub prereleases, unsupported channels, and tag/package version mismatches.
  - Runs in the `npm` environment on Node.js 24 with minimal permissions and npm provenance.

- **Migration**
  - Configure Trusted Publisher on npm:
    - Publisher: GitHub Actions
    - Organization: `InsForge`
    - Repository: `InsForge-sdk-js`
    - Workflow: `publish.yml`
    - Environment: `npm`
    - Allowed action: `npm publish`

<sup>Written for commit 2ecf8f68e5443f315dc4de00aba475eb51d06152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish npm releases via trusted publishing in GitHub Actions
> Adds [publish.yml](.github/workflows/publish.yml) to automate npm publishing on GitHub Releases or tag pushes matching `v*`.
>
> - Validates the tag format, matches it against `package.json` version, and derives the npm dist-tag (`latest` for stable `vX.Y.Z`, or `alpha`/`beta`/`rc` for prereleases)
> - Runs the full quality pipeline before publishing: `npm ci`, format check, lint, typecheck, tests, build, and a dry-run `npm pack`
> - Publishes with `--access public` and the computed dist-tag using OIDC-based trusted publishing (no stored npm token needed)
> - Disallows prerelease GitHub Releases; prereleases must use tag pushes only
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ecf8f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated package publishing to npm for stable and prerelease versions.
  * Added validation to ensure release tags match the package version and use supported formats.
  * Added automated quality checks and packaging verification before publication.
  * Stable releases use the `latest` channel; prereleases are published to their corresponding alpha, beta, or release-candidate channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->