### PR TITLE
chore: prepare 1.4.5-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.4",
+  "version": "1.4.5-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.4.4",
+      "version": "1.4.5-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.4",
+  "version": "1.4.5-beta.0",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

- bump `@insforge/sdk` from `1.4.4` to `1.4.5-beta.0`
- keep `package.json` and `package-lock.json` versions aligned

## Why

This prepares a unique prerelease version for the first end-to-end npm Trusted Publishing verification. After this PR is merged, pushing `v1.4.5-beta.0` will trigger `publish.yml` and publish the package to the npm `beta` dist-tag.

## Validation

- `npm run format:check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run typecheck`
- `npm run test:run` (193 tests passed)
- `npm run build`
- `npm pack --dry-run` (`@insforge/sdk@1.4.5-beta.0`, 29 files)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@insforge/sdk` to 1.4.5-beta.0 to prepare a prerelease for the first end-to-end npm Trusted Publishing verification. Align `package.json` and `package-lock.json` versions so tagging `v1.4.5-beta.0` triggers `publish.yml` and publishes to the `beta` dist-tag.

<sup>Written for commit 4e47d30f6638ec09f24e7cca2918ea918eed5c2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

