### PR TITLE
ci: pin npm publish actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Validate release channel and version
         id: release
@@ -67,7 +67,7 @@ jobs:
           console.log(`Validated @insforge/sdk@${packageVersion} for npm tag ${distTag}`);
           NODE
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

- pin `actions/checkout` and `actions/setup-node` in the npm publish workflow to the full commit SHAs currently referenced by their version tags
- retain version comments for readability and automated updates
- leave Trusted Publishing, package version validation, and release-channel behavior unchanged

## Validation

- `actionlint .github/workflows/publish.yml`
- Node 24: format check, lint (0 errors), typecheck, 193 unit tests, build, and `npm pack --dry-run`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `actions/checkout` and `actions/setup-node` in the npm publish workflow to v6 commit SHAs for reproducible and more secure releases. Enable Dependabot (weekly) for GitHub Actions to track updates; no changes to Trusted Publishing, release-channel logic, or package version validation.

<sup>Written for commit 4f463fdea805d8b1db954f1aca321767cb23d761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin npm publish actions to specific commit SHAs
> Pins `actions/checkout` and `actions/setup-node` in [publish.yml](.github/workflows/publish.yml) to full commit SHAs instead of mutable version tags. Also adds a [Dependabot config](.github/workflows/dependabot.yml) to keep GitHub Actions dependencies up to date on a weekly schedule.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f463fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->