### PR TITLE
ci: require stable releases from main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Validate release channel and version
         id: release
@@ -66,6 +68,17 @@ jobs:
           appendFileSync(process.env.GITHUB_OUTPUT, `dist_tag=${distTag}\n`);
           console.log(`Validated @insforge/sdk@${packageVersion} for npm tag ${distTag}`);
           NODE
+
+      - name: Verify stable release commit is in main
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          release_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          if ! git merge-base --is-ancestor "$release_commit" origin/main; then
+            echo "Stable release $RELEASE_TAG must point to a commit contained in main." >&2
+            exit 1
+          fi
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:


### PR DESCRIPTION
## Summary
- require stable GitHub releases to resolve to commits contained in `main`
- preserve prerelease tag publishing from non-main branches
- fetch full history for ancestry validation

## Verification
- `actionlint .github/workflows/publish.yml`
- `npm run format:check`
- `npm run lint` (existing warnings only)
- `npm run typecheck`
- `npm run test:run` (193 tests)
- `npm run build`
- `npm pack --dry-run`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require stable release tags to point to a commit in main
> - Adds a new step in [publish.yml](.github/workflows/publish.yml) that runs on release events and verifies the release tag's commit is an ancestor of `origin/main` using `git merge-base --is-ancestor`, failing with an error if not.
> - Fetches the full git history (`fetch-depth: 0`) in the checkout step so ancestry checks work correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22023e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release validation by ensuring release tags reference commits included in the main branch.
  * Release workflows now have access to the complete repository history for more reliable verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->