### PR TITLE
test: decouple realtime integration auth policy

### DIFF
--- a/integration-tests/realtime.test.ts
+++ b/integration-tests/realtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { signUpAndSignIn, createClient } from './setup';
+import type { SubscribeResponse } from '@insforge/shared-schemas';
+import { createClient } from './setup';
 import type { InsForgeClient } from '../src/client';
 
 /**
@@ -20,18 +21,27 @@ import type { InsForgeClient } from '../src/client';
  *   realtime.socketId             (getter)
  *
  * NOTE: Realtime requires a socket.io server on the test project.
+ * These API-level tests intentionally use the project's anonymous access
+ * policy. Authenticated handshake token selection is covered by unit tests,
+ * so these tests do not depend on the fixed test user's channel RLS policy.
  * If the server is unreachable the tests verify that errors are
  * properly surfaced rather than crashing.
  */
+
+function expectSuccessfulSubscription(response: SubscribeResponse, channel: string): void {
+  const failure = response.ok
+    ? undefined
+    : `${response.error?.code ?? 'UNKNOWN'}: ${response.error?.message ?? 'No error message'}`;
+
+  expect(response, failure).toMatchObject({ ok: true, channel });
+}
 
 describe('Realtime Module', () => {
   let client: InsForgeClient;
   let realtimeAvailable = true;
 
-  beforeAll(async () => {
-    const result = await signUpAndSignIn();
-    expect(result.error).toBeNull();
-    client = result.client;
+  beforeAll(() => {
+    client = createClient();
   });
 
   afterAll(() => {
@@ -153,8 +163,7 @@ describe('Realtime Module', () => {
       const response = await client.realtime.subscribe(channel);
 
       expect(response).toBeDefined();
-      expect(response.ok).toBe(true);
-      expect(response.channel).toBe(channel);
+      expectSuccessfulSubscription(response, channel);
       expect(client.realtime.getSubscribedChannels()).toContain(channel);
     });
 
@@ -164,11 +173,12 @@ describe('Realtime Module', () => {
       }
 
       const channel = `dup-${Date.now()}`;
-      await client.realtime.subscribe(channel);
+      const first = await client.realtime.subscribe(channel);
+      expectSuccessfulSubscription(first, channel);
       const second = await client.realtime.subscribe(channel);
 
       // Second call returns cached success
-      expect(second.ok).toBe(true);
+      expectSuccessfulSubscription(second, channel);
     });
 
     it('unsubscribe() should remove the channel', async () => {
@@ -177,7 +187,8 @@ describe('Realtime Module', () => {
       }
 
       const channel = `unsub-${Date.now()}`;
-      await client.realtime.subscribe(channel);
+      const response = await client.realtime.subscribe(channel);
+      expectSuccessfulSubscription(response, channel);
       expect(client.realtime.getSubscribedChannels()).toContain(channel);
 
       client.realtime.unsubscribe(channel);
@@ -239,7 +250,8 @@ describe('Realtime Module', () => {
       }
 
       const channel = `pub-${Date.now()}`;
-      await client.realtime.subscribe(channel);
+      const response = await client.realtime.subscribe(channel);
+      expectSuccessfulSubscription(response, channel);
 
       // Should not throw
       await client.realtime.publish(channel, 'test-event', { ts: Date.now() });
@@ -266,8 +278,10 @@ describe('Realtime Module', () => {
 
       const ch1 = `ch1-${Date.now()}`;
       const ch2 = `ch2-${Date.now()}`;
-      await client.realtime.subscribe(ch1);
-      await client.realtime.subscribe(ch2);
+      const response1 = await client.realtime.subscribe(ch1);
+      const response2 = await client.realtime.subscribe(ch2);
+      expectSuccessfulSubscription(response1, ch1);
+      expectSuccessfulSubscription(response2, ch2);
 
       const channels = client.realtime.getSubscribedChannels();
       expect(Array.isArray(channels)).toBe(true);

--- a/src/modules/__tests__/realtime.test.ts
+++ b/src/modules/__tests__/realtime.test.ts
@@ -150,6 +150,29 @@ describe('Realtime', () => {
     await vi.waitFor(() => expect(callback).toHaveBeenCalledWith({ token: refreshedToken }));
   });
 
+  it('prefers the resolved user access token over the anonymous key for a handshake', async () => {
+    const userToken = jwt(300);
+    const getValidAccessToken = vi.fn().mockResolvedValue(userToken);
+    const realtime = new Realtime(
+      'http://example.test',
+      new TokenManager(),
+      'anon-project-key',
+      getValidAccessToken
+    );
+    await connect(realtime);
+
+    if (typeof socketOptions?.auth !== 'function') {
+      expect(socketOptions?.auth).toBeTypeOf('function');
+      return;
+    }
+    const auth = socketOptions.auth as (callback: (payload: { token?: string }) => void) => void;
+    const callback = vi.fn();
+    auth(callback);
+
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith({ token: userToken }));
+    expect(getValidAccessToken).toHaveBeenCalledOnce();
+  });
+
   it('does not restore a subscription when an acknowledgement arrives after unsubscribe', async () => {
     const realtime = new Realtime('http://example.test', new TokenManager());
     await connect(realtime);


### PR DESCRIPTION
## Summary

- run the generic Realtime integration suite with the integration project's anonymous channel policy instead of coupling it to the fixed test user's RLS policy
- add assertion context so subscription failures report the backend error code and message
- add a unit regression test proving a resolved signed-in user token still takes precedence over the anonymous project key during Socket.IO handshakes

## Root cause

The Realtime integration suite began failing after the SDK correctly switched server-mode Socket.IO handshakes from the anonymous key to the signed-in user's JWT. The shared integration project permits the anonymous role for its public test channels but does not grant the fixed authenticated test user the same channel access. That made generic subscribe/unsubscribe API tests depend on an unrelated authenticated RLS fixture.

This change keeps the corrected SDK authentication behavior and tests it directly, while making the public Realtime API integration tests use the role their backend fixture is configured for.

## Validation

- `npm run format`
- `npm run format:check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run typecheck`
- `npm run test:run` (194 tests passed)
- `npm run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples Realtime integration tests from the fixed authenticated user by using the project's anonymous channel policy. Stabilizes the suite and verifies user JWTs still take precedence in Socket.IO handshakes.

- **Bug Fixes**
  - Run API-level tests with anonymous channel access; remove reliance on the fixed user's RLS.
  - Add subscribe assertion helper that reports backend error code and message on failure.
  - Add unit regression test that prefers the resolved user token over the anonymous key during Socket.IO handshake.

<sup>Written for commit ff53709c013bb8728f27aa08d9aac08c086675c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Decouple realtime integration tests from authenticated auth policy
> - Replaces `signUpAndSignIn()` with `createClient()` in [realtime.test.ts](https://github.com/InsForge/InsForge-sdk-js/pull/112/files#diff-db766c138baf01a8503f100fc6a122d9c03418175791b8b506fcd16f67012916) so tests use anonymous access instead of requiring authentication.
> - Adds an `expectSuccessfulSubscription` helper that centralizes subscribe response assertions with clearer failure messages.
> - Adds a unit test in [realtime.test.ts](https://github.com/InsForge/InsForge-sdk-js/pull/112/files#diff-5513792e24906062c7287d694864e7d2632155086a1d7c5df1ab5791ddc360e4) confirming the handshake prefers a resolved user access token over an anonymous project key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff53709.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved realtime integration test coverage using anonymous access and shared subscription validation.
  * Added coverage confirming authenticated realtime connections prefer a resolved user access token when available.
  * Strengthened checks for successful subscriptions before publishing or listing channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->