### PR TITLE
chore: bump version to 1.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

- bump `@insforge/sdk` from `1.4.4` to `1.4.5`
- keep `package.json` and `package-lock.json` in sync

## Why

npm currently publishes `1.4.4` as `latest` and `1.4.5-beta.0` as `beta`. This prepares the tested main branch for a stable `v1.4.5` GitHub Release. Once merged, publishing the stable GitHub Release will invoke the Trusted Publisher workflow and promote `1.4.5` to npm `latest`.

## Validation

- `npm run format`
- `npm run format:check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run typecheck`
- `npm run test:run` (194 tests passed)
- `npm run build`
- `npm --cache /private/tmp/insforge-sdk-npm-cache pack --dry-run`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@insforge/sdk` from 1.4.4 to 1.4.5 and sync `package-lock.json` to prepare the stable release. This allows promoting 1.4.5 to npm `latest` via the Trusted Publisher after the GitHub Release is published.

<sup>Written for commit e8782f34bf704bd058e54831537355767000fa11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to 1.4.5
> Updates the version field in [package.json](https://github.com/InsForge/InsForge-sdk-js/pull/113/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from 1.4.4 to 1.4.5.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8782f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 1.4.4 to 1.4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->