### PR TITLE
storage: standard PUT semantics and server-generated auto keys

### DIFF
--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -714,6 +714,7 @@ const bucket = insforge.storage.from('avatars');
 await bucket.upload('path/file.jpg', file);
 // Response: { data: StorageFileSchema, error }
 // data: { bucket, key, size, mimeType, uploadedAt, url }
+// Replaces the existing object when the path is already in use
 ```
 
 ### `bucket.uploadAuto()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.4.5",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -146,6 +146,134 @@ describe('StorageBucket.createSignedUrl', () => {
   });
 });
 
+describe('StorageBucket.upload upsert semantics', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const storedFile = {
+    bucket: 'docs',
+    key: 'report.pdf',
+    size: 3,
+    mimeType: 'application/pdf',
+    uploadedAt: '2026-01-01T00:00:00.000Z',
+    url: 'http://localhost:7130/api/storage/buckets/docs/objects/report.pdf',
+  };
+
+  it('sends upsert to upload-strategy and the direct PUT URL', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          method: 'direct',
+          uploadUrl: '/api/storage/buckets/docs/objects/report.pdf',
+          key: 'report.pdf',
+          confirmRequired: false,
+        })
+      )
+      .mockResolvedValueOnce(jsonRes(200, storedFile));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.upload('report.pdf', new Blob(['abc']), { upsert: true });
+
+    expect(result.error).toBeNull();
+    const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
+    expect(strategyBody.upsert).toBe(true);
+    const putUrl = new URL(String(fetchFn.mock.calls[1][0]));
+    expect(putUrl.pathname).toBe('/api/storage/buckets/docs/objects/report.pdf');
+    expect(putUrl.searchParams.get('upsert')).toBe('true');
+  });
+
+  it('omits the upsert query param by default', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          method: 'direct',
+          uploadUrl: '/api/storage/buckets/docs/objects/report.pdf',
+          key: 'report.pdf',
+          confirmRequired: false,
+        })
+      )
+      .mockResolvedValueOnce(jsonRes(201, storedFile));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.upload('report.pdf', new Blob(['abc']));
+
+    expect(result.error).toBeNull();
+    const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
+    expect(strategyBody.upsert).toBe(false);
+    const putUrl = new URL(String(fetchFn.mock.calls[1][0]));
+    expect(putUrl.searchParams.get('upsert')).toBeNull();
+  });
+
+  it('surfaces the 409 conflict from upload-strategy as an InsForgeError', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        jsonRes(
+          409,
+          { error: 'STORAGE_ALREADY_EXISTS', message: 'Object "report.pdf" already exists' },
+          'Conflict'
+        )
+      );
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.upload('report.pdf', new Blob(['abc']));
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBeInstanceOf(InsForgeError);
+    expect(result.error?.statusCode).toBe(409);
+  });
+
+  it('passes upsert through to the presigned confirm step', async () => {
+    // The presigned upload itself goes through the global fetch, not the
+    // injected HTTP client — stub it separately.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          method: 'presigned',
+          uploadUrl: 'https://s3.example.com/upload',
+          key: 'report.pdf',
+          confirmRequired: true,
+          confirmUrl: '/api/storage/buckets/docs/objects/report.pdf/confirm-upload',
+        })
+      )
+      .mockResolvedValueOnce(jsonRes(200, storedFile)); // confirm
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.upload('report.pdf', new Blob(['abc']), { upsert: true });
+    vi.unstubAllGlobals();
+
+    expect(result.error).toBeNull();
+    const confirmBody = JSON.parse(String(fetchFn.mock.calls[1][1]?.body));
+    expect(confirmBody.upsert).toBe(true);
+  });
+
+  it('uploadAuto requests a server-minted key via autoKey', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          method: 'direct',
+          uploadUrl: '/api/storage/buckets/docs/objects',
+          key: 'report-123-abc.pdf',
+          confirmRequired: false,
+        })
+      )
+      .mockResolvedValueOnce(jsonRes(201, { ...storedFile, key: 'report-123-abc.pdf' }));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.uploadAuto(new Blob(['abc']));
+
+    expect(result.error).toBeNull();
+    const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
+    expect(strategyBody.autoKey).toBe(true);
+  });
+});
+
 describe('StorageBucket.createSignedUrls', () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -146,7 +146,7 @@ describe('StorageBucket.createSignedUrl', () => {
   });
 });
 
-describe('StorageBucket.upload upsert semantics', () => {
+describe('StorageBucket.upload / uploadAuto (standard PUT semantics)', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
@@ -160,7 +160,7 @@ describe('StorageBucket.upload upsert semantics', () => {
     url: 'http://localhost:7130/api/storage/buckets/docs/objects/report.pdf',
   };
 
-  it('sends upsert to upload-strategy and the direct PUT URL', async () => {
+  it('uploads to the exact key via the direct PUT route, no upsert flag', async () => {
     const fetchFn = vi
       .fn()
       .mockResolvedValueOnce(
@@ -174,47 +174,26 @@ describe('StorageBucket.upload upsert semantics', () => {
       .mockResolvedValueOnce(jsonRes(200, storedFile));
     const bucket = new StorageBucket('docs', makeHttp(fetchFn));
 
-    const result = await bucket.upload('report.pdf', new Blob(['abc']), { upsert: true });
-
-    expect(result.error).toBeNull();
-    const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
-    expect(strategyBody.upsert).toBe(true);
-    const putUrl = new URL(String(fetchFn.mock.calls[1][0]));
-    expect(putUrl.pathname).toBe('/api/storage/buckets/docs/objects/report.pdf');
-    expect(putUrl.searchParams.get('upsert')).toBe('true');
-  });
-
-  it('omits the upsert query param by default', async () => {
-    const fetchFn = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonRes(200, {
-          method: 'direct',
-          uploadUrl: '/api/storage/buckets/docs/objects/report.pdf',
-          key: 'report.pdf',
-          confirmRequired: false,
-        })
-      )
-      .mockResolvedValueOnce(jsonRes(201, storedFile));
-    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
-
     const result = await bucket.upload('report.pdf', new Blob(['abc']));
 
     expect(result.error).toBeNull();
     const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
-    expect(strategyBody.upsert).toBe(false);
-    const putUrl = new URL(String(fetchFn.mock.calls[1][0]));
-    expect(putUrl.searchParams.get('upsert')).toBeNull();
+    expect(strategyBody.filename).toBe('report.pdf');
+    expect(strategyBody).not.toHaveProperty('upsert');
+    const putUrl = new URL(String(fetchFn.mock.calls[1][0]), 'http://localhost');
+    expect(putUrl.pathname).toBe('/api/storage/buckets/docs/objects/report.pdf');
+    expect(putUrl.search).toBe('');
+    expect(String(fetchFn.mock.calls[1][1]?.method)).toBe('PUT');
   });
 
-  it('surfaces the 409 conflict from upload-strategy as an InsForgeError', async () => {
+  it('surfaces a backend error as an InsForgeError', async () => {
     const fetchFn = vi
       .fn()
       .mockResolvedValue(
         jsonRes(
-          409,
-          { error: 'STORAGE_ALREADY_EXISTS', message: 'Object "report.pdf" already exists' },
-          'Conflict'
+          403,
+          { error: 'STORAGE_PERMISSION_DENIED', message: 'You do not have permission' },
+          'Forbidden'
         )
       );
     const bucket = new StorageBucket('docs', makeHttp(fetchFn));
@@ -223,10 +202,10 @@ describe('StorageBucket.upload upsert semantics', () => {
 
     expect(result.data).toBeNull();
     expect(result.error).toBeInstanceOf(InsForgeError);
-    expect(result.error?.statusCode).toBe(409);
+    expect(result.error?.statusCode).toBe(403);
   });
 
-  it('passes upsert through to the presigned confirm step', async () => {
+  it('confirms a presigned upload without an upsert flag', async () => {
     // The presigned upload itself goes through the global fetch, not the
     // injected HTTP client — stub it separately.
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
@@ -244,33 +223,43 @@ describe('StorageBucket.upload upsert semantics', () => {
       .mockResolvedValueOnce(jsonRes(200, storedFile)); // confirm
     const bucket = new StorageBucket('docs', makeHttp(fetchFn));
 
-    const result = await bucket.upload('report.pdf', new Blob(['abc']), { upsert: true });
+    const result = await bucket.upload('report.pdf', new Blob(['abc']));
     vi.unstubAllGlobals();
 
     expect(result.error).toBeNull();
     const confirmBody = JSON.parse(String(fetchFn.mock.calls[1][1]?.body));
-    expect(confirmBody.upsert).toBe(true);
+    expect(confirmBody).not.toHaveProperty('upsert');
+    expect(confirmBody.size).toBe(3);
   });
 
-  it('uploadAuto requests a server-minted key via autoKey', async () => {
+  it('uploadAuto mints a unique key client-side and uploads via the standard path', async () => {
     const fetchFn = vi
       .fn()
-      .mockResolvedValueOnce(
-        jsonRes(200, {
-          method: 'direct',
-          uploadUrl: '/api/storage/buckets/docs/objects',
-          key: 'report-123-abc.pdf',
-          confirmRequired: false,
-        })
-      )
-      .mockResolvedValueOnce(jsonRes(201, { ...storedFile, key: 'report-123-abc.pdf' }));
+      .mockImplementationOnce((_url, init) => {
+        // Strategy call — echo a direct URL for whatever key was requested.
+        const body = JSON.parse(String(init?.body));
+        return Promise.resolve(
+          jsonRes(200, {
+            method: 'direct',
+            uploadUrl: `/api/storage/buckets/docs/objects/${encodeURIComponent(body.filename)}`,
+            key: body.filename,
+            confirmRequired: false,
+          })
+        );
+      })
+      .mockResolvedValueOnce(jsonRes(200, storedFile));
     const bucket = new StorageBucket('docs', makeHttp(fetchFn));
 
-    const result = await bucket.uploadAuto(new Blob(['abc']));
+    const result = await bucket.uploadAuto(
+      new File(['abc'], 'report.pdf', { type: 'application/pdf' })
+    );
 
     expect(result.error).toBeNull();
     const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
-    expect(strategyBody.autoKey).toBe(true);
+    // Client-generated key: sanitized base + timestamp + random, preserving ext.
+    expect(strategyBody.filename).toMatch(/^report-\d+-[a-z0-9]+\.pdf$/);
+    expect(strategyBody).not.toHaveProperty('autoKey');
+    expect(String(fetchFn.mock.calls[1][1]?.method)).toBe('PUT');
   });
 });
 

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -179,6 +179,7 @@ describe('StorageBucket.upload / uploadAuto (standard PUT semantics)', () => {
     expect(result.error).toBeNull();
     const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
     expect(strategyBody.filename).toBe('report.pdf');
+    expect(strategyBody).not.toHaveProperty('autoKey');
     expect(strategyBody).not.toHaveProperty('upsert');
     const putUrl = new URL(String(fetchFn.mock.calls[1][0]), 'http://localhost');
     expect(putUrl.pathname).toBe('/api/storage/buckets/docs/objects/report.pdf');
@@ -232,33 +233,42 @@ describe('StorageBucket.upload / uploadAuto (standard PUT semantics)', () => {
     expect(confirmBody.size).toBe(3);
   });
 
-  it('uploadAuto mints a unique key client-side and uploads via the standard path', async () => {
+  it('uploadAuto requests a server-generated key and uploads to that exact key', async () => {
+    const generatedFile = {
+      ...storedFile,
+      key: 'report-123-abc.pdf',
+      url: 'http://localhost:7130/api/storage/buckets/docs/objects/report-123-abc.pdf',
+    };
     const fetchFn = vi
       .fn()
-      .mockImplementationOnce((_url, init) => {
-        // Strategy call — echo a direct URL for whatever key was requested.
-        const body = JSON.parse(String(init?.body));
-        return Promise.resolve(
-          jsonRes(200, {
-            method: 'direct',
-            uploadUrl: `/api/storage/buckets/docs/objects/${encodeURIComponent(body.filename)}`,
-            key: body.filename,
-            confirmRequired: false,
-          })
-        );
-      })
-      .mockResolvedValueOnce(jsonRes(200, storedFile));
+      .mockResolvedValueOnce(
+        jsonRes(200, {
+          method: 'direct',
+          uploadUrl: '/api/storage/buckets/docs/objects/report-123-abc.pdf',
+          key: 'report-123-abc.pdf',
+          confirmRequired: false,
+        })
+      )
+      .mockResolvedValueOnce(jsonRes(200, generatedFile));
     const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+    const file = Object.assign(new Blob(['abc'], { type: 'application/pdf' }), {
+      name: 'report.pdf',
+    });
 
-    const result = await bucket.uploadAuto(
-      new File(['abc'], 'report.pdf', { type: 'application/pdf' })
-    );
+    const result = await bucket.uploadAuto(file);
 
     expect(result.error).toBeNull();
+    expect(result.data?.key).toBe('report-123-abc.pdf');
     const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
-    // Client-generated key: sanitized base + timestamp + random, preserving ext.
-    expect(strategyBody.filename).toMatch(/^report-\d+-[a-z0-9]+\.pdf$/);
-    expect(strategyBody).not.toHaveProperty('autoKey');
+    expect(strategyBody).toMatchObject({
+      filename: 'report.pdf',
+      contentType: 'application/pdf',
+      size: 3,
+      autoKey: true,
+    });
+    const putUrl = new URL(String(fetchFn.mock.calls[1][0]), 'http://localhost');
+    expect(putUrl.pathname).toBe('/api/storage/buckets/docs/objects/report-123-abc.pdf');
+    expect(putUrl.search).toBe('');
     expect(String(fetchFn.mock.calls[1][1]?.method)).toBe('PUT');
   });
 });

--- a/src/modules/__tests__/storage.test.ts
+++ b/src/modules/__tests__/storage.test.ts
@@ -233,23 +233,22 @@ describe('StorageBucket.upload / uploadAuto (standard PUT semantics)', () => {
     expect(confirmBody.size).toBe(3);
   });
 
-  it('uploadAuto requests a server-generated key and uploads to that exact key', async () => {
-    const generatedFile = {
-      ...storedFile,
-      key: 'report-123-abc.pdf',
-      url: 'http://localhost:7130/api/storage/buckets/docs/objects/report-123-abc.pdf',
-    };
+  it('uploadAuto mints a unique key client-side and uploads via the standard path', async () => {
     const fetchFn = vi
       .fn()
-      .mockResolvedValueOnce(
-        jsonRes(200, {
-          method: 'direct',
-          uploadUrl: '/api/storage/buckets/docs/objects/report-123-abc.pdf',
-          key: 'report-123-abc.pdf',
-          confirmRequired: false,
-        })
-      )
-      .mockResolvedValueOnce(jsonRes(200, generatedFile));
+      .mockImplementationOnce((_url, init) => {
+        // Strategy call — echo a direct URL for whatever key was requested.
+        const body = JSON.parse(String(init?.body));
+        return Promise.resolve(
+          jsonRes(200, {
+            method: 'direct',
+            uploadUrl: `/api/storage/buckets/docs/objects/${encodeURIComponent(body.filename)}`,
+            key: body.filename,
+            confirmRequired: false,
+          })
+        );
+      })
+      .mockResolvedValueOnce(jsonRes(200, storedFile));
     const bucket = new StorageBucket('docs', makeHttp(fetchFn));
     const file = Object.assign(new Blob(['abc'], { type: 'application/pdf' }), {
       name: 'report.pdf',
@@ -258,18 +257,41 @@ describe('StorageBucket.upload / uploadAuto (standard PUT semantics)', () => {
     const result = await bucket.uploadAuto(file);
 
     expect(result.error).toBeNull();
-    expect(result.data?.key).toBe('report-123-abc.pdf');
     const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
-    expect(strategyBody).toMatchObject({
-      filename: 'report.pdf',
-      contentType: 'application/pdf',
-      size: 3,
-      autoKey: true,
-    });
+    // Client-generated key: sanitized base + timestamp + random, preserving ext.
+    expect(strategyBody.filename).toMatch(/^report-\d+-[a-z0-9]+\.pdf$/);
+    // autoKey is gone — the backend no longer mints keys.
+    expect(strategyBody).not.toHaveProperty('autoKey');
+    // Uploads to the client-minted key via the standard PUT route.
     const putUrl = new URL(String(fetchFn.mock.calls[1][0]), 'http://localhost');
-    expect(putUrl.pathname).toBe('/api/storage/buckets/docs/objects/report-123-abc.pdf');
-    expect(putUrl.search).toBe('');
+    expect(putUrl.pathname).toBe(
+      `/api/storage/buckets/docs/objects/${encodeURIComponent(strategyBody.filename)}`
+    );
     expect(String(fetchFn.mock.calls[1][1]?.method)).toBe('PUT');
+  });
+
+  it('uploadAuto falls back to a "file" base when the Blob has no name (Node 18 safe)', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockImplementationOnce((_url, init) => {
+        const body = JSON.parse(String(init?.body));
+        return Promise.resolve(
+          jsonRes(200, {
+            method: 'direct',
+            uploadUrl: `/api/storage/buckets/docs/objects/${encodeURIComponent(body.filename)}`,
+            key: body.filename,
+            confirmRequired: false,
+          })
+        );
+      })
+      .mockResolvedValueOnce(jsonRes(200, storedFile));
+    const bucket = new StorageBucket('docs', makeHttp(fetchFn));
+
+    const result = await bucket.uploadAuto(new Blob(['abc']));
+
+    expect(result.error).toBeNull();
+    const strategyBody = JSON.parse(String(fetchFn.mock.calls[0][1]?.body));
+    expect(strategyBody.filename).toMatch(/^file-\d+-[a-z0-9]+$/);
   });
 });
 

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -29,22 +29,6 @@ interface DownloadStrategy {
 }
 
 /**
- * Generate a unique object key from a filename: `<sanitized-base>-<timestamp>-<random><ext>`.
- * Mirrors the backend's key generation so `uploadAuto` produces the same
- * shape of key without a server round-trip. Browser-safe (no node `path`).
- */
-function generateObjectKey(filename: string): string {
-  const dotIndex = filename.lastIndexOf('.');
-  const hasExt = dotIndex > 0;
-  const ext = hasExt ? filename.slice(dotIndex) : '';
-  const base = hasExt ? filename.slice(0, dotIndex) : filename;
-  const sanitizedBase = base.replace(/[^a-zA-Z0-9-_]/g, '-').slice(0, 32) || 'file';
-  const timestamp = Date.now();
-  const random = Math.random().toString(36).slice(2, 8);
-  return `${sanitizedBase}-${timestamp}-${random}${ext}`;
-}
-
-/**
  * Storage bucket operations
  */
 export class StorageBucket {
@@ -114,16 +98,54 @@ export class StorageBucket {
   }
 
   /**
-   * Upload a file under an automatically generated, collision-free key.
-   * The key is derived client-side from the filename (sanitized base +
-   * timestamp + random suffix), then uploaded through the standard
-   * {@link upload} path — so repeated uploads of the same file never
-   * overwrite each other.
+   * Upload a file under a server-generated key.
+   * Uses the upload strategy from the backend (direct or presigned).
    * @param file - File or Blob to upload
    */
   async uploadAuto(file: File | Blob): Promise<StorageResponse<StorageFileSchema>> {
-    const filename = file instanceof File ? file.name : 'file';
-    return this.upload(generateObjectKey(filename), file);
+    try {
+      const filename = 'name' in file && typeof file.name === 'string' ? file.name : 'file';
+      const strategyResponse = await this.http.post<UploadStrategy>(
+        `/api/storage/buckets/${this.bucketName}/upload-strategy`,
+        {
+          filename,
+          contentType: file.type || 'application/octet-stream',
+          size: file.size,
+          autoKey: true,
+        }
+      );
+
+      if (strategyResponse.method === 'presigned') {
+        return await this.uploadWithPresignedUrl(strategyResponse, file);
+      }
+
+      if (strategyResponse.method === 'direct') {
+        const formData = new FormData();
+        formData.append('file', file);
+
+        const response = await this.http.request<StorageFileSchema>(
+          'PUT',
+          `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(strategyResponse.key)}`,
+          { body: formData as any }
+        );
+
+        return { data: response, error: null };
+      }
+
+      throw new InsForgeError(
+        `Unsupported upload method: ${strategyResponse.method}`,
+        500,
+        'STORAGE_ERROR'
+      );
+    } catch (error) {
+      return {
+        data: null,
+        error:
+          error instanceof InsForgeError
+            ? error
+            : new InsForgeError('Upload failed', 500, 'STORAGE_ERROR'),
+      };
+    }
   }
 
   /**

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -29,6 +29,23 @@ interface DownloadStrategy {
 }
 
 /**
+ * Generate a unique object key from a filename: `<sanitized-base>-<timestamp>-<random><ext>`.
+ * Auto-key generation is a client-side convenience — the storage API has no
+ * server-side key minting — so `uploadAuto` produces the key here and then
+ * uploads through the standard `upload()` path. Browser-safe (no node `path`).
+ */
+function generateObjectKey(filename: string): string {
+  const dotIndex = filename.lastIndexOf('.');
+  const hasExt = dotIndex > 0;
+  const ext = hasExt ? filename.slice(dotIndex) : '';
+  const base = hasExt ? filename.slice(0, dotIndex) : filename;
+  const sanitizedBase = base.replace(/[^a-zA-Z0-9-_]/g, '-').slice(0, 32) || 'file';
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${sanitizedBase}-${timestamp}-${random}${ext}`;
+}
+
+/**
  * Storage bucket operations
  */
 export class StorageBucket {
@@ -98,54 +115,17 @@ export class StorageBucket {
   }
 
   /**
-   * Upload a file under a server-generated key.
-   * Uses the upload strategy from the backend (direct or presigned).
+   * Upload a file under an automatically generated, collision-free key.
+   * The key is derived client-side from the filename (sanitized base +
+   * timestamp + random suffix) and uploaded through the standard
+   * {@link upload} path, so repeated uploads of the same file never
+   * overwrite each other. Reads the filename structurally to avoid assuming
+   * a global `File` (which Node 18 does not expose).
    * @param file - File or Blob to upload
    */
   async uploadAuto(file: File | Blob): Promise<StorageResponse<StorageFileSchema>> {
-    try {
-      const filename = 'name' in file && typeof file.name === 'string' ? file.name : 'file';
-      const strategyResponse = await this.http.post<UploadStrategy>(
-        `/api/storage/buckets/${this.bucketName}/upload-strategy`,
-        {
-          filename,
-          contentType: file.type || 'application/octet-stream',
-          size: file.size,
-          autoKey: true,
-        }
-      );
-
-      if (strategyResponse.method === 'presigned') {
-        return await this.uploadWithPresignedUrl(strategyResponse, file);
-      }
-
-      if (strategyResponse.method === 'direct') {
-        const formData = new FormData();
-        formData.append('file', file);
-
-        const response = await this.http.request<StorageFileSchema>(
-          'PUT',
-          `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(strategyResponse.key)}`,
-          { body: formData as any }
-        );
-
-        return { data: response, error: null };
-      }
-
-      throw new InsForgeError(
-        `Unsupported upload method: ${strategyResponse.method}`,
-        500,
-        'STORAGE_ERROR'
-      );
-    } catch (error) {
-      return {
-        data: null,
-        error:
-          error instanceof InsForgeError
-            ? error
-            : new InsForgeError('Upload failed', 500, 'STORAGE_ERROR'),
-      };
-    }
+    const filename = 'name' in file && typeof file.name === 'string' ? file.name : 'file';
+    return this.upload(generateObjectKey(filename), file);
   }
 
   /**

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -42,8 +42,16 @@ export class StorageBucket {
    * Uses the upload strategy from backend (direct or presigned)
    * @param path - The object key/path
    * @param file - File or Blob to upload
+   * @param options - Set `upsert: true` to replace an existing object at
+   *   this key. Without it, uploading to an existing key fails with 409
+   *   (STORAGE_ALREADY_EXISTS).
    */
-  async upload(path: string, file: File | Blob): Promise<StorageResponse<StorageFileSchema>> {
+  async upload(
+    path: string,
+    file: File | Blob,
+    options?: { upsert?: boolean }
+  ): Promise<StorageResponse<StorageFileSchema>> {
+    const upsert = options?.upsert === true;
     try {
       // Get upload strategy from backend - this is required
       const strategyResponse = await this.http.post<UploadStrategy>(
@@ -52,12 +60,13 @@ export class StorageBucket {
           filename: path,
           contentType: file.type || 'application/octet-stream',
           size: file.size,
+          upsert,
         }
       );
 
       // Use presigned URL if available
       if (strategyResponse.method === 'presigned') {
-        return await this.uploadWithPresignedUrl(strategyResponse, file);
+        return await this.uploadWithPresignedUrl(strategyResponse, file, { upsert });
       }
 
       // Use direct upload if strategy says so
@@ -67,7 +76,7 @@ export class StorageBucket {
 
         const response = await this.http.request<StorageFileSchema>(
           'PUT',
-          `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}`,
+          `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}${upsert ? '?upsert=true' : ''}`,
           {
             body: formData as any,
             headers: {
@@ -104,13 +113,16 @@ export class StorageBucket {
     try {
       const filename = file instanceof File ? file.name : 'file';
 
-      // Get upload strategy from backend - this is required
+      // Get upload strategy from backend - this is required.
+      // autoKey asks the server to mint a unique key from the filename, so
+      // repeated uploads of the same file never collide.
       const strategyResponse = await this.http.post<UploadStrategy>(
         `/api/storage/buckets/${this.bucketName}/upload-strategy`,
         {
           filename,
           contentType: file.type || 'application/octet-stream',
           size: file.size,
+          autoKey: true,
         }
       );
 
@@ -159,7 +171,8 @@ export class StorageBucket {
    */
   private async uploadWithPresignedUrl(
     strategy: UploadStrategy,
-    file: File | Blob
+    file: File | Blob,
+    options?: { upsert?: boolean }
   ): Promise<StorageResponse<StorageFileSchema>> {
     try {
       // Upload to presigned URL (e.g., S3)
@@ -188,11 +201,14 @@ export class StorageBucket {
         );
       }
 
-      // Confirm upload with backend if required
+      // Confirm upload with backend if required. The upsert flag must match
+      // the strategy request so confirming a replacement updates the
+      // existing metadata row instead of failing as "already confirmed".
       if (strategy.confirmRequired && strategy.confirmUrl) {
         const confirmResponse = await this.http.post<StorageFileSchema>(strategy.confirmUrl, {
           size: file.size,
           contentType: file.type || 'application/octet-stream',
+          upsert: options?.upsert === true,
         });
 
         return { data: confirmResponse, error: null };

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -29,6 +29,22 @@ interface DownloadStrategy {
 }
 
 /**
+ * Generate a unique object key from a filename: `<sanitized-base>-<timestamp>-<random><ext>`.
+ * Mirrors the backend's key generation so `uploadAuto` produces the same
+ * shape of key without a server round-trip. Browser-safe (no node `path`).
+ */
+function generateObjectKey(filename: string): string {
+  const dotIndex = filename.lastIndexOf('.');
+  const hasExt = dotIndex > 0;
+  const ext = hasExt ? filename.slice(dotIndex) : '';
+  const base = hasExt ? filename.slice(0, dotIndex) : filename;
+  const sanitizedBase = base.replace(/[^a-zA-Z0-9-_]/g, '-').slice(0, 32) || 'file';
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${sanitizedBase}-${timestamp}-${random}${ext}`;
+}
+
+/**
  * Storage bucket operations
  */
 export class StorageBucket {
@@ -38,20 +54,14 @@ export class StorageBucket {
   ) {}
 
   /**
-   * Upload a file with a specific key
-   * Uses the upload strategy from backend (direct or presigned)
+   * Upload a file to a specific key.
+   * Uses the upload strategy from the backend (direct or presigned).
+   * Standard PUT semantics: uploading to an existing key replaces the
+   * current object in place.
    * @param path - The object key/path
    * @param file - File or Blob to upload
-   * @param options - Set `upsert: true` to replace an existing object at
-   *   this key. Without it, uploading to an existing key fails with 409
-   *   (STORAGE_ALREADY_EXISTS).
    */
-  async upload(
-    path: string,
-    file: File | Blob,
-    options?: { upsert?: boolean }
-  ): Promise<StorageResponse<StorageFileSchema>> {
-    const upsert = options?.upsert === true;
+  async upload(path: string, file: File | Blob): Promise<StorageResponse<StorageFileSchema>> {
     try {
       // Get upload strategy from backend - this is required
       const strategyResponse = await this.http.post<UploadStrategy>(
@@ -60,69 +70,6 @@ export class StorageBucket {
           filename: path,
           contentType: file.type || 'application/octet-stream',
           size: file.size,
-          upsert,
-        }
-      );
-
-      // Use presigned URL if available
-      if (strategyResponse.method === 'presigned') {
-        return await this.uploadWithPresignedUrl(strategyResponse, file, { upsert });
-      }
-
-      // Use direct upload if strategy says so
-      if (strategyResponse.method === 'direct') {
-        const formData = new FormData();
-        formData.append('file', file);
-
-        const response = await this.http.request<StorageFileSchema>(
-          'PUT',
-          `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}${upsert ? '?upsert=true' : ''}`,
-          {
-            body: formData as any,
-            headers: {
-              // Don't set Content-Type, let browser set multipart boundary
-            },
-          }
-        );
-
-        return { data: response, error: null };
-      }
-
-      throw new InsForgeError(
-        `Unsupported upload method: ${strategyResponse.method}`,
-        500,
-        'STORAGE_ERROR'
-      );
-    } catch (error) {
-      return {
-        data: null,
-        error:
-          error instanceof InsForgeError
-            ? error
-            : new InsForgeError('Upload failed', 500, 'STORAGE_ERROR'),
-      };
-    }
-  }
-
-  /**
-   * Upload a file with auto-generated key
-   * Uses the upload strategy from backend (direct or presigned)
-   * @param file - File or Blob to upload
-   */
-  async uploadAuto(file: File | Blob): Promise<StorageResponse<StorageFileSchema>> {
-    try {
-      const filename = file instanceof File ? file.name : 'file';
-
-      // Get upload strategy from backend - this is required.
-      // autoKey asks the server to mint a unique key from the filename, so
-      // repeated uploads of the same file never collide.
-      const strategyResponse = await this.http.post<UploadStrategy>(
-        `/api/storage/buckets/${this.bucketName}/upload-strategy`,
-        {
-          filename,
-          contentType: file.type || 'application/octet-stream',
-          size: file.size,
-          autoKey: true,
         }
       );
 
@@ -137,8 +84,8 @@ export class StorageBucket {
         formData.append('file', file);
 
         const response = await this.http.request<StorageFileSchema>(
-          'POST',
-          `/api/storage/buckets/${this.bucketName}/objects`,
+          'PUT',
+          `/api/storage/buckets/${this.bucketName}/objects/${encodeURIComponent(path)}`,
           {
             body: formData as any,
             headers: {
@@ -167,12 +114,24 @@ export class StorageBucket {
   }
 
   /**
+   * Upload a file under an automatically generated, collision-free key.
+   * The key is derived client-side from the filename (sanitized base +
+   * timestamp + random suffix), then uploaded through the standard
+   * {@link upload} path — so repeated uploads of the same file never
+   * overwrite each other.
+   * @param file - File or Blob to upload
+   */
+  async uploadAuto(file: File | Blob): Promise<StorageResponse<StorageFileSchema>> {
+    const filename = file instanceof File ? file.name : 'file';
+    return this.upload(generateObjectKey(filename), file);
+  }
+
+  /**
    * Internal method to handle presigned URL uploads
    */
   private async uploadWithPresignedUrl(
     strategy: UploadStrategy,
-    file: File | Blob,
-    options?: { upsert?: boolean }
+    file: File | Blob
   ): Promise<StorageResponse<StorageFileSchema>> {
     try {
       // Upload to presigned URL (e.g., S3)
@@ -201,14 +160,12 @@ export class StorageBucket {
         );
       }
 
-      // Confirm upload with backend if required. The upsert flag must match
-      // the strategy request so confirming a replacement updates the
-      // existing metadata row instead of failing as "already confirmed".
+      // Confirm upload with backend if required. Confirm create-or-replaces
+      // the metadata row, matching the standard PUT semantics.
       if (strategy.confirmRequired && strategy.confirmUrl) {
         const confirmResponse = await this.http.post<StorageFileSchema>(strategy.confirmUrl, {
           size: file.size,
           contentType: file.type || 'application/octet-stream',
-          upsert: options?.upsert === true,
         });
 
         return { data: confirmResponse, error: null };


### PR DESCRIPTION
## Summary

- Make upload(path, file) use standard exact-key PUT semantics: creating and replacing both use the same request, with no upsert option.
- Keep uploadAuto(file) as the explicit convenience API for unique objects: it requests autoKey from the InsForge upload-strategy endpoint and uploads to the server-returned key for both direct and presigned strategies.
- Avoid the Node 18 global File assumption by reading the optional name property structurally.
- Document that uploading to an existing path replaces it.

The exact-key PUT behavior aligns with InsForge/InsForge#1760. autoKey is an InsForge upload-strategy convenience and is intentionally separate from the standard object PUT contract.

## Validation

- Node 18: full unit suite, 198 tests passed
- Node 20: full unit suite, 198 tests passed
- Node 22: format check, typecheck, lint (existing warnings only), build, and full unit suite passed
- GitHub CI: Node 18/20/22 tests, lint/format, typecheck, and build passed
- Deployed storage fixture: all 14 storage checks and the S3 validator passed in https://github.com/InsForge/agent-e2e/actions/runs/29789534785 (overall run has the known unrelated /api/ai/config 404)

Companion E2E: InsForge/agent-e2e#12.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Summary
>
> - Make upload(path, file) use standard exact-key PUT semantics: creating and replacing both use the same request, with no upsert option.
> - Keep uploadAuto(file) as the explicit convenience API for unique objects: it requests autoKey from the InsForge upload-strategy endpoint and uploads to the server-returned key for both direct and presigned strategies.
> - Avoid the Node 18 global File assumption by reading the optional name property structurally.
> - Document that uploading to an existing path replaces it.
>
> The exact-key PUT behavior aligns with InsForge/InsForge#1760. autoKey is an InsForge upload-strategy convenience and is intentionally separate from the standard object PUT contract.
>
> ## Validation
>
> - Node 18: full unit suite, 198 tests passed
> - Node 20: full unit suite, 198 tests passed
> - Node 22: format check, typecheck, lint (existing warnings only), build, and full unit suite passed
> - GitHub CI: Node 18/20/22 tests, lint/format, typecheck, and build passed
> - Deployed storage fixture: all 14 storage checks and the S3 validator passed in https://github.com/InsForge/agent-e2e/actions/runs/29789534785 (overall run has the known unrelated /api/ai/config 404)
>
> Companion E2E: InsForge/agent-e2e#12.<!-- Macroscope's changelog starts here -->
> #### Changes since #114 opened
>
> - Replaced server-generated auto keys with client-side key generation in `StorageBucket.uploadAuto` method [fd969b9]
> - Updated tests to validate client-side key generation semantics in `StorageBucket.uploadAuto` [fd969b9]
> - Bumped package version to 1.5.0 [f15d5d7]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `uploadAuto` now creates unique client-side object names (timestamp/random suffix) while preserving the file extension.
  * Uploads gracefully handle unnamed blobs by using a generated fallback filename.
* **Bug Fixes**
  * Uploading to an existing object path now consistently follows standard replacement (PUT) semantics.
  * Improved error handling for non-success responses, including correct HTTP status preservation.
* **Documentation**
  * Updated bucket upload docs to clarify replacement behavior for existing paths.
* **Tests**
  * Expanded coverage for upload/confirmation flows and filename/key generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->