### PR TITLE
feat(auth): add email OTP sign-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/sdk",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@insforge/shared-schemas": "^1.2.0",
+        "@insforge/shared-schemas": "^1.2.1",
         "@supabase/postgrest-js": "^1.21.3",
         "socket.io-client": "^4.8.1"
       },
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@insforge/shared-schemas": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.2.0.tgz",
-      "integrity": "sha512-qUYNXkCKVPTKXC/jWtG+FEgH/NFY0d2EnEgjYj8vu+R6wezGpKXP8T0rSMtoavgXo1ZcOTCR8+pQJBWJSR9BvA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@insforge/shared-schemas/-/shared-schemas-1.2.1.tgz",
+      "integrity": "sha512-3DCfzmlyH8t0NEjXZmI4/J7W6eaTsSa72K89WWeTDnnPtaPoFHJVSS8lTLsi0p3KFkA8gU6e5IOZemSi5TDW1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Official JavaScript/TypeScript client for InsForge Backend-as-a-Service platform",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "url": "https://github.com/InsForge/insforge-sdk-js/issues"
   },
   "dependencies": {
-    "@insforge/shared-schemas": "^1.2.0",
+    "@insforge/shared-schemas": "^1.2.1",
     "@supabase/postgrest-js": "^1.21.3",
     "socket.io-client": "^4.8.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
   UserSchema,
   CreateUserRequest,
   CreateSessionRequest,
+  SendOTPRequest,
   AuthErrorResponse,
   DeleteObjectResult,
   DeleteObjectsResponse,
@@ -32,6 +33,7 @@ export type {
 
 // Re-export auth module for advanced usage
 export { Auth } from './modules/auth/auth';
+export type { PasswordSessionRequest, VerifyOtpRequest } from './modules/auth/auth';
 
 // Re-export database module (using postgrest-js)
 export { Database } from './modules/database-postgrest';

--- a/src/modules/auth/__tests__/auth.test.ts
+++ b/src/modules/auth/__tests__/auth.test.ts
@@ -311,6 +311,8 @@ describe('Auth', () => {
         { baseUrl: 'http://localhost:7130', fetch: fetchMock as any, retryCount: 0, timeout: 0 },
         new TokenManager()
       );
+      const setAuthTokenSpy = vi.spyOn(http, 'setAuthToken');
+      const setRefreshTokenSpy = vi.spyOn(http, 'setRefreshToken');
       const auth = new Auth(http, new TokenManager(), { isServerMode: true });
 
       const { data, error } = await auth.verifyOtp({
@@ -321,6 +323,9 @@ describe('Auth', () => {
 
       expect(error).toBeNull();
       expect(data?.accessToken).toBe('access-token');
+      // The session must be persisted — this is what distinguishes verifyOtp from signInWithOtp.
+      expect(setAuthTokenSpy).toHaveBeenCalledWith('access-token');
+      expect(setRefreshTokenSpy).toHaveBeenCalledWith('refresh-token');
 
       const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
       const url = new URL(requestUrl);
@@ -332,6 +337,32 @@ describe('Auth', () => {
         otp: '123456',
         name: 'Ada Lovelace',
       });
+    });
+
+    it('signs in through the browser sessions endpoint (no client_type) and stores the session', async () => {
+      const session = {
+        user: { id: 'u1', email: 'user@example.com', emailVerified: true },
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      };
+      const fetchMock = vi.fn().mockResolvedValue(createJsonResponse(200, session));
+      const tokenManager = new TokenManager();
+      const http = new HttpClient(
+        { baseUrl: 'http://localhost:7130', fetch: fetchMock as any, retryCount: 0, timeout: 0 },
+        tokenManager
+      );
+      const auth = new Auth(http, tokenManager, { isServerMode: false });
+
+      const { data, error } = await auth.verifyOtp({ email: 'user@example.com', otp: '123456' });
+
+      expect(error).toBeNull();
+      expect(data?.accessToken).toBe('access-token');
+      // Browser mode persists the session to the token manager.
+      expect(tokenManager.getAccessToken()).toBe('access-token');
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/auth/sessions');
+      expect(url.searchParams.get('client_type')).toBeNull();
     });
   });
 });

--- a/src/modules/auth/__tests__/auth.test.ts
+++ b/src/modules/auth/__tests__/auth.test.ts
@@ -273,4 +273,65 @@ describe('Auth', () => {
       expect(headers.has('X-CSRF-Token')).toBe(false);
     });
   });
+
+  describe('signInWithOtp()', () => {
+    it('posts the email to the send-otp endpoint and returns the generic success payload', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        createJsonResponse(202, {
+          success: true,
+          message: 'If sign-in is available for this email, we have sent a verification code.',
+        })
+      );
+      const http = new HttpClient(
+        { baseUrl: 'http://localhost:7130', fetch: fetchMock as any, retryCount: 0, timeout: 0 },
+        new TokenManager()
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      const { data, error } = await auth.signInWithOtp({ email: 'user@example.com' });
+
+      expect(error).toBeNull();
+      expect(data?.success).toBe(true);
+
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(new URL(requestUrl).pathname).toBe('/api/auth/email/send-otp');
+      expect(JSON.parse(requestInit.body as string)).toEqual({ email: 'user@example.com' });
+    });
+  });
+
+  describe('verifyOtp()', () => {
+    it('verifies the code via the sessions endpoint with method "otp" and returns a session', async () => {
+      const session = {
+        user: { id: 'u1', email: 'user@example.com', emailVerified: true },
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      };
+      const fetchMock = vi.fn().mockResolvedValue(createJsonResponse(200, session));
+      const http = new HttpClient(
+        { baseUrl: 'http://localhost:7130', fetch: fetchMock as any, retryCount: 0, timeout: 0 },
+        new TokenManager()
+      );
+      const auth = new Auth(http, new TokenManager(), { isServerMode: true });
+
+      const { data, error } = await auth.verifyOtp({
+        email: 'user@example.com',
+        otp: '123456',
+        name: 'Ada Lovelace',
+      });
+
+      expect(error).toBeNull();
+      expect(data?.accessToken).toBe('access-token');
+
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const url = new URL(requestUrl);
+      expect(url.pathname).toBe('/api/auth/sessions');
+      expect(url.searchParams.get('client_type')).toBe('mobile');
+      expect(JSON.parse(requestInit.body as string)).toEqual({
+        method: 'otp',
+        email: 'user@example.com',
+        otp: '123456',
+        name: 'Ada Lovelace',
+      });
+    });
+  });
 });

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -29,6 +29,7 @@ import {
   type CreateUserResponse,
   type CreateSessionRequest,
   type CreateSessionResponse,
+  type SendOTPRequest,
   type GetOauthUrlResponse,
   type GetPublicAuthConfigResponse,
   type OAuthInitRequest,
@@ -60,6 +61,12 @@ type OAuthSignInOptions = {
 type OAuthSignInLegacyOptions = OAuthSignInOptions & {
   provider: OAuthProvidersSchema | string;
 };
+
+/** Credentials for the password sign-in flow (excludes the OTP session variant). */
+export type PasswordSessionRequest = Exclude<CreateSessionRequest, { method: 'otp' }>;
+
+/** Payload for {@link Auth.verifyOtp}: the email OTP session variant without the discriminator. */
+export type VerifyOtpRequest = Omit<Extract<CreateSessionRequest, { method: 'otp' }>, 'method'>;
 
 export class Auth {
   private authCallbackHandled: Promise<void>;
@@ -180,7 +187,7 @@ export class Auth {
     }
   }
 
-  async signInWithPassword(request: CreateSessionRequest): Promise<{
+  async signInWithPassword(request: PasswordSessionRequest): Promise<{
     data: CreateSessionResponse | null;
     error: InsForgeError | null;
   }> {
@@ -188,6 +195,56 @@ export class Auth {
       const response = await this.http.post<CreateSessionResponse>(
         this.isServerMode() ? '/api/auth/sessions?client_type=mobile' : '/api/auth/sessions',
         request,
+        { credentials: 'include', skipAuthRefresh: true }
+      );
+
+      this.saveSessionFromResponse(response);
+      if (response.refreshToken) {
+        this.http.setRefreshToken(response.refreshToken);
+      }
+
+      return { data: response, error: null };
+    } catch (error) {
+      return wrapError(error, 'An unexpected error occurred during sign in');
+    }
+  }
+
+  /**
+   * Send a one-time sign-in code to an email address.
+   *
+   * The response is intentionally generic whether or not an account exists, to
+   * avoid account enumeration. Complete the flow with {@link Auth.verifyOtp}.
+   */
+  async signInWithOtp(request: SendOTPRequest): Promise<{
+    data: { success: boolean; message: string } | null;
+    error: InsForgeError | null;
+  }> {
+    try {
+      const response = await this.http.post<{ success: boolean; message: string }>(
+        '/api/auth/email/send-otp',
+        request,
+        { skipAuthRefresh: true }
+      );
+      return { data: response, error: null };
+    } catch (error) {
+      return wrapError(error, 'An unexpected error occurred while sending the sign-in code');
+    }
+  }
+
+  /**
+   * Verify an email sign-in code and create a session.
+   *
+   * If the email is new, a verified passwordless user is created; `name` sets
+   * the display name only on that first-time creation.
+   */
+  async verifyOtp(request: VerifyOtpRequest): Promise<{
+    data: CreateSessionResponse | null;
+    error: InsForgeError | null;
+  }> {
+    try {
+      const response = await this.http.post<CreateSessionResponse>(
+        this.isServerMode() ? '/api/auth/sessions?client_type=mobile' : '/api/auth/sessions',
+        { method: 'otp', ...request },
         { credentials: 'include', skipAuthRefresh: true }
       );
 

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -244,7 +244,8 @@ export class Auth {
     try {
       const response = await this.http.post<CreateSessionResponse>(
         this.isServerMode() ? '/api/auth/sessions?client_type=mobile' : '/api/auth/sessions',
-        { method: 'otp', ...request },
+        // method is set last so it can never be clobbered by an untyped caller's payload.
+        { ...request, method: 'otp' },
         { credentials: 'include', skipAuthRefresh: true }
       );
 

--- a/src/ssr/auth-actions.ts
+++ b/src/ssr/auth-actions.ts
@@ -49,6 +49,8 @@ export interface AuthActions {
   signInWithIdToken: SafeAuthAction<InsForgeClient['auth']['signInWithIdToken']>;
   exchangeOAuthCode: SafeAuthAction<InsForgeClient['auth']['exchangeOAuthCode']>;
   verifyEmail: SafeAuthAction<InsForgeClient['auth']['verifyEmail']>;
+  signInWithOtp: InsForgeClient['auth']['signInWithOtp'];
+  verifyOtp: SafeAuthAction<InsForgeClient['auth']['verifyOtp']>;
   signOut: InsForgeClient['auth']['signOut'];
 }
 
@@ -158,6 +160,16 @@ export function createAuthActions(options: CreateAuthActionsOptions = {}): AuthA
       const result = await createClient().auth.verifyEmail(request);
       persistSessionCookies(writeCookies, result.data, cookieSettings);
       return toSafeAuthResult<InsForgeClient['auth']['verifyEmail']>(result);
+    },
+
+    signInWithOtp: async (request) => {
+      return createClient().auth.signInWithOtp(request);
+    },
+
+    verifyOtp: async (request) => {
+      const result = await createClient().auth.verifyOtp(request);
+      persistSessionCookies(writeCookies, result.data, cookieSettings);
+      return toSafeAuthResult<InsForgeClient['auth']['verifyOtp']>(result);
     },
 
     signOut: async () => {


### PR DESCRIPTION
## Summary

Exposes the passwordless email OTP sign-in flow shipped in the backend ([InsForge#1798](https://github.com/InsForge/InsForge/pull/1798)). Two new `auth` methods:

- **`auth.signInWithOtp({ email })`** → `POST /api/auth/email/send-otp`. Requests a 6-digit code; returns the backend's generic `202 { success, message }` (identical whether or not the account exists, to avoid enumeration).
- **`auth.verifyOtp({ email, otp, name? })`** → `POST /api/auth/sessions` with `method: 'otp'`. Verifies the code and creates a session, persisting it exactly like `signInWithPassword`. `name` sets the display name only when the account is first created (new emails become verified passwordless users).

SSR (`createAuthActions`) mirrors both: `verifyOtp` persists session cookies; `signInWithOtp` is a passthrough (no cookies).

## Types / dependency

- Bumps `@insforge/shared-schemas` to `^1.2.1` (the discriminated-union `CreateSessionRequest` + `SendOTPRequest`).
- Re-exports `SendOTPRequest`, plus `PasswordSessionRequest` and `VerifyOtpRequest` helper types.
- Narrows `signInWithPassword` to `PasswordSessionRequest` (the password variant). **Not a breaking change** — existing `{ email, password }` calls still typecheck, and the backend still defaults an absent `method` to `'password'`, so this release is purely additive.

## Validation

- `npm run typecheck` (incl. `tsconfig.type-tests.json`)
- `npm run lint` (0 new errors in changed files)
- `npm run test:run` — added unit tests for `signInWithOtp` and `verifyOtp` (endpoint, `method:'otp'` body, session persistence); full `src` suite green
- `npm run build`

## Notes

- Version bump left to the release process (didn't touch `package.json` `version`).
- README has no per-method auth section, so no docs change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds passwordless email OTP sign-in via `auth.signInWithOtp` and `auth.verifyOtp`, with SSR support. `verifyOtp` now forces `method: 'otp'` to prevent payload clobbering and ensures session persistence.

- **New Features**
  - `auth.signInWithOtp({ email })` → POST `/api/auth/email/send-otp`; returns a generic 202 response to prevent account enumeration.
  - `auth.verifyOtp({ email, otp, name? })` → POST `/api/auth/sessions` with `method: 'otp'` (set last to avoid being overridden); creates and persists a session. Appends `client_type=mobile` in server mode; SSR mirrors both and `verifyOtp` persists cookies.
  - Exported types: `SendOTPRequest`, `PasswordSessionRequest`, `VerifyOtpRequest`. `signInWithPassword` narrowed to `PasswordSessionRequest` (non-breaking).

- **Dependencies**
  - Bumped `@insforge/shared-schemas` to `^1.2.1`.

<sup>Written for commit 83a29cede47dab20bc34ed85901d37df5d09996d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add email OTP sign-in via `Auth.signInWithOtp` and `Auth.verifyOtp`
> - Adds `Auth.signInWithOtp` in [auth.ts](https://github.com/InsForge/InsForge-sdk-js/pull/120/files#diff-b7f37dce2f7643f69ad65823f77dc7fe8162410502cc185cd2d7bf5e3931a9cc) which posts to `/api/auth/email/send-otp` and returns a generic success payload without creating a session.
> - Adds `Auth.verifyOtp` which posts to `/api/auth/sessions` with `method: 'otp'`, persisting access and refresh tokens on success (in server mode, appends `client_type=mobile`).
> - Exposes both methods on the SSR surface in [auth-actions.ts](https://github.com/InsForge/InsForge-sdk-js/pull/120/files#diff-15da7fcfe2644e028f021f1648b24fba1765a10a0448009d56aa1dc195080f5b): `signInWithOtp` delegates directly to the client, while `verifyOtp` also persists session cookies.
> - Narrows `signInWithPassword` to `PasswordSessionRequest`, which excludes `method: 'otp'`.
> - Bumps package to `1.5.1` and updates `@insforge/shared-schemas` to `^1.2.1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d19071.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passwordless email authentication with one-time passcodes.
  * Added support for sending OTP codes and verifying them to create a session.
  * Added public TypeScript request types for password and OTP authentication.
  * Server-side authentication actions now support OTP verification and session persistence.

* **Bug Fixes**
  * Improved authentication request typing to distinguish password and OTP flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->