### PR TITLE
fix(ssr): hydrate the current user on a browser cold load

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import type { InsForgeConfig } from './types';
+import type { AuthSession, InsForgeConfig } from './types';
 import { HttpClient } from './lib/http-client';
 import { Logger } from './lib/logger';
 import { AuthChangeEvent, TokenManager } from './lib/token-manager';
@@ -146,6 +146,24 @@ export class InsForgeClient {
     } else {
       this.tokenManager.setAccessToken(token, event);
     }
+  }
+
+  /**
+   * Record a session that was established outside the SDK — an app-owned
+   * refresh route, for example, which answers with both a token and the user
+   * it belongs to.
+   *
+   * `setAccessToken()` stores a token with no user behind it, which leaves
+   * `auth.getCurrentUser()` unable to answer from memory: it holds a token but
+   * no identity, so it goes back to the network for one. Pass both here when
+   * you have both.
+   */
+  setSession(
+    session: AuthSession,
+    event: AccessTokenChangeEvent = AuthChangeEvent.SIGNED_IN
+  ): void {
+    this.http.setAuthToken(session.accessToken);
+    this.tokenManager.saveSession(session, event);
   }
 
   /**

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -536,6 +536,13 @@ export class Auth {
     }
   }
 
+  /** Resolve the user an access token we already hold belongs to. */
+  private async fetchCurrentUser(accessToken: string): Promise<UserSchema | null> {
+    this.http.setAuthToken(accessToken);
+    const response = await this.http.get<{ user: UserSchema }>('/api/auth/sessions/current');
+    return response.user ?? null;
+  }
+
   /**
    * Get current user, automatically waits for pending OAuth callback
    */
@@ -546,16 +553,14 @@ export class Auth {
     await this.authCallbackHandled;
 
     try {
+      const accessToken = this.tokenManager.getAccessToken();
+
       if (this.isServerMode()) {
-        const accessToken = this.tokenManager.getAccessToken();
         if (!accessToken) {
           return { data: { user: null }, error: null };
         }
 
-        this.http.setAuthToken(accessToken);
-        const response = await this.http.get<{ user: UserSchema }>('/api/auth/sessions/current');
-        const user = response.user ?? null;
-        return { data: { user }, error: null };
+        return { data: { user: await this.fetchCurrentUser(accessToken) }, error: null };
       }
 
       // Browser mode: check memory first
@@ -565,8 +570,31 @@ export class Auth {
         return { data: { user: session.user }, error: null };
       }
 
-      // Try refresh via httpOnly cookie (browser only)
       if (typeof window !== 'undefined') {
+        // A cold page load can hold an access token with no user behind it:
+        // createBrowserClient() hydrates the token from the readable
+        // insforge_access_token cookie, and setAccessToken() stores a token
+        // without a user, so getSession() above is null. Resolve the user with
+        // the token we already have. Falling straight through to the refresh
+        // below would post to the InsForge origin, which the httpOnly refresh
+        // cookie never reaches when it is scoped to the app's own domain.
+        if (accessToken) {
+          try {
+            const user = await this.fetchCurrentUser(accessToken);
+            if (user) {
+              this.tokenManager.setUser(user);
+              return { data: { user }, error: null };
+            }
+          } catch (error) {
+            // A rejected token is not fatal here — the refresh below mints a
+            // new one. Anything else is a real failure and should surface.
+            if (!(error instanceof InsForgeError) || error.statusCode !== 401) {
+              throw error;
+            }
+          }
+        }
+
+        // Try refresh via httpOnly cookie (browser only)
         const { data: refreshed, error: refreshError } = await this.refreshSession();
         if (refreshError) {
           return { data: { user: null }, error: refreshError };

--- a/src/modules/auth/auth.ts
+++ b/src/modules/auth/auth.ts
@@ -536,10 +536,18 @@ export class Auth {
     }
   }
 
-  /** Resolve the user an access token we already hold belongs to. */
+  /**
+   * Resolve the user an access token we already hold belongs to.
+   *
+   * `skipAuthRefresh` keeps a rejected token from tripping the HTTP client's
+   * own refresh: callers here decide what a 401 means, and in the browser that
+   * decision belongs to whoever owns the refresh cookie.
+   */
   private async fetchCurrentUser(accessToken: string): Promise<UserSchema | null> {
     this.http.setAuthToken(accessToken);
-    const response = await this.http.get<{ user: UserSchema }>('/api/auth/sessions/current');
+    const response = await this.http.get<{ user: UserSchema }>('/api/auth/sessions/current', {
+      skipAuthRefresh: true,
+    });
     return response.user ?? null;
   }
 

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -271,6 +271,7 @@ describe('@insforge/sdk/ssr cookies', () => {
       fetch: fetch as any,
     });
     const { data, error } = await client.auth.getCurrentUser();
+    const callsAfterFirstRead = fetch.mock.calls.length;
     await client.auth.getCurrentUser();
 
     expect(error).toBeNull();
@@ -280,6 +281,36 @@ describe('@insforge/sdk/ssr cookies', () => {
     // to the InsForge origin, for the user or for a refresh.
     expect(fetch).toHaveBeenCalledWith('/api/auth/refresh', expect.anything());
     expect(insForgeOriginCalls(fetch)).toHaveLength(0);
+    // Not even a second trip to the app route: the first read cached the user.
+    expect(fetch.mock.calls).toHaveLength(callsAfterFirstRead);
+  });
+
+  it('uses a session handed in through setSession without refreshing', async () => {
+    const token = jwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', { cookie: '' });
+    const fetch = vi.fn(async () =>
+      jsonResponse(401, {
+        error: ERROR_CODES.AUTH_UNAUTHORIZED,
+        message: 'No refresh token provided',
+        statusCode: 401,
+      })
+    );
+
+    const client = createBrowserClient({
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    client.setSession({ accessToken: token, user: { id: 'user-4' } as any });
+    const { data, error } = await client.auth.getCurrentUser();
+
+    expect(error).toBeNull();
+    expect(data.user).toMatchObject({ id: 'user-4' });
+    expect(client.getHttpClient().getHeaders().Authorization).toBe(`Bearer ${token}`);
+    // The cold-load refresh fired before the session was handed in; the read
+    // itself must not reach for the network again.
+    expect(fetch.mock.calls.filter(([url]) => String(url) !== '/api/auth/refresh')).toHaveLength(0);
   });
 
   it('resolves the current user through the app refresh route when the access-token cookie is expired', async () => {

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -30,6 +30,16 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+/**
+ * Refresh calls aimed at the InsForge origin. The app's httpOnly refresh
+ * cookie is scoped to the app's own domain, so these can only ever 401.
+ */
+function insForgeOriginRefreshCalls(fetch: { mock: { calls: unknown[][] } }) {
+  return fetch.mock.calls.filter(([url]) =>
+    /^https:\/\/api\.insforge\.test\S*refresh$/.test(String(url))
+  );
+}
+
 function cookieStore(initial: Record<string, string> = {}) {
   const values = new Map(Object.entries(initial));
   const options = new Map<string, CookieOptions>();
@@ -239,10 +249,14 @@ describe('@insforge/sdk/ssr cookies', () => {
 
   it('resolves the current user through the app refresh route when the access-token cookie is gone', async () => {
     const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    vi.stubGlobal('window', {});
     vi.stubGlobal('document', { cookie: '' });
     const fetch = vi.fn(async (url: string) => {
       if (url === '/api/auth/refresh') {
         return jsonResponse(200, { accessToken, user: { id: 'user-2' } });
+      }
+      if (url === 'https://api.insforge.test/api/auth/sessions/current') {
+        return jsonResponse(200, { user: { id: 'user-2' } });
       }
       return jsonResponse(401, {
         error: ERROR_CODES.AUTH_UNAUTHORIZED,
@@ -257,14 +271,14 @@ describe('@insforge/sdk/ssr cookies', () => {
       fetch: fetch as any,
     });
     const { data, error } = await client.auth.getCurrentUser();
+    // The user the route resolved is cached, so a second read is free.
+    const callsAfterFirstRead = fetch.mock.calls.length;
+    await client.auth.getCurrentUser();
 
     expect(error).toBeNull();
     expect(data.user).toMatchObject({ id: 'user-2' });
-    expect(
-      fetch.mock.calls.filter(([url]: [string]) =>
-        String(url).startsWith('https://api.insforge.test')
-      )
-    ).toHaveLength(0);
+    expect(fetch.mock.calls).toHaveLength(callsAfterFirstRead);
+    expect(insForgeOriginRefreshCalls(fetch)).toHaveLength(0);
   });
 
   it('resolves the current user through the app refresh route when the access-token cookie is expired', async () => {
@@ -277,6 +291,9 @@ describe('@insforge/sdk/ssr cookies', () => {
     const fetch = vi.fn(async (url: string) => {
       if (url === '/api/auth/refresh') {
         return jsonResponse(200, { accessToken: freshToken, user: { id: 'user-3' } });
+      }
+      if (url === 'https://api.insforge.test/api/auth/sessions/current') {
+        return jsonResponse(200, { user: { id: 'user-3' } });
       }
       return jsonResponse(401, {
         error: ERROR_CODES.AUTH_UNAUTHORIZED,
@@ -294,11 +311,7 @@ describe('@insforge/sdk/ssr cookies', () => {
 
     expect(error).toBeNull();
     expect(data.user).toMatchObject({ id: 'user-3' });
-    expect(
-      fetch.mock.calls.filter(([url]: [string]) =>
-        String(url).startsWith('https://api.insforge.test')
-      )
-    ).toHaveLength(0);
+    expect(insForgeOriginRefreshCalls(fetch)).toHaveLength(0);
   });
 
   it('stops at the app refresh route when it reports no session', async () => {

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -31,13 +31,13 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 /**
- * Refresh calls aimed at the InsForge origin. The app's httpOnly refresh
- * cookie is scoped to the app's own domain, so these can only ever 401.
+ * Calls aimed at the InsForge origin rather than the app's own routes. A
+ * refresh sent there can only ever 401 — the app's httpOnly refresh cookie is
+ * scoped to the app's domain — and a user lookup sent there is a round trip
+ * for something the refresh route already returned.
  */
-function insForgeOriginRefreshCalls(fetch: { mock: { calls: unknown[][] } }) {
-  return fetch.mock.calls.filter(([url]) =>
-    /^https:\/\/api\.insforge\.test\S*refresh$/.test(String(url))
-  );
+function insForgeOriginCalls(fetch: { mock: { calls: unknown[][] } }) {
+  return fetch.mock.calls.filter(([url]) => String(url).startsWith('https://api.insforge.test'));
 }
 
 function cookieStore(initial: Record<string, string> = {}) {
@@ -271,14 +271,15 @@ describe('@insforge/sdk/ssr cookies', () => {
       fetch: fetch as any,
     });
     const { data, error } = await client.auth.getCurrentUser();
-    // The user the route resolved is cached, so a second read is free.
-    const callsAfterFirstRead = fetch.mock.calls.length;
     await client.auth.getCurrentUser();
 
     expect(error).toBeNull();
     expect(data.user).toMatchObject({ id: 'user-2' });
-    expect(fetch.mock.calls).toHaveLength(callsAfterFirstRead);
-    expect(insForgeOriginRefreshCalls(fetch)).toHaveLength(0);
+    // The app route is the only thing that can mint a token here, and the
+    // session it returns is recorded whole — so neither read needs a request
+    // to the InsForge origin, for the user or for a refresh.
+    expect(fetch).toHaveBeenCalledWith('/api/auth/refresh', expect.anything());
+    expect(insForgeOriginCalls(fetch)).toHaveLength(0);
   });
 
   it('resolves the current user through the app refresh route when the access-token cookie is expired', async () => {
@@ -311,7 +312,8 @@ describe('@insforge/sdk/ssr cookies', () => {
 
     expect(error).toBeNull();
     expect(data.user).toMatchObject({ id: 'user-3' });
-    expect(insForgeOriginRefreshCalls(fetch)).toHaveLength(0);
+    expect(fetch).toHaveBeenCalledWith('/api/auth/refresh', expect.anything());
+    expect(insForgeOriginCalls(fetch)).toHaveLength(0);
   });
 
   it('stops at the app refresh route when it reports no session', async () => {
@@ -336,11 +338,7 @@ describe('@insforge/sdk/ssr cookies', () => {
     expect(data.user).toBeNull();
     // Falling through to the base client here would refresh against the
     // InsForge origin, which cannot see the app's httpOnly cookie.
-    expect(
-      fetch.mock.calls.filter(([url]: [string]) =>
-        String(url).startsWith('https://api.insforge.test')
-      )
-    ).toHaveLength(0);
+    expect(insForgeOriginCalls(fetch)).toHaveLength(0);
   });
 
   it('refreshes through the app route before a browser request when access token is missing', async () => {

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -183,6 +183,90 @@ describe('@insforge/sdk/ssr cookies', () => {
     expect(client.getHttpClient().getHeaders().Authorization).toBe(`Bearer ${token}`);
   });
 
+  it('resolves the current user from the access-token cookie on a cold load', async () => {
+    const token = jwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {
+      cookie: `insforge_access_token=${encodeURIComponent(token)}`,
+    });
+    const fetch = vi.fn(async (url: string) => {
+      if (url === 'https://api.insforge.test/api/auth/sessions/current') {
+        return jsonResponse(200, { user: { id: 'user-1' } });
+      }
+      return jsonResponse(401, {
+        error: ERROR_CODES.AUTH_UNAUTHORIZED,
+        message: 'No refresh token provided',
+        statusCode: 401,
+      });
+    });
+
+    const client = createBrowserClient({
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const { data, error } = await client.auth.getCurrentUser();
+
+    expect(error).toBeNull();
+    expect(data.user).toMatchObject({ id: 'user-1' });
+    // The InsForge-origin refresh endpoint cannot see the app's httpOnly
+    // refresh cookie, so reaching for it here would always 401.
+    expect(fetch).not.toHaveBeenCalledWith(
+      'https://api.insforge.test/api/auth/refresh',
+      expect.anything()
+    );
+  });
+
+  it('serves a second current-user read from memory', async () => {
+    const token = jwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {
+      cookie: `insforge_access_token=${encodeURIComponent(token)}`,
+    });
+    const fetch = vi.fn(async () => jsonResponse(200, { user: { id: 'user-1' } }));
+
+    const client = createBrowserClient({
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    await client.auth.getCurrentUser();
+    const { data } = await client.auth.getCurrentUser();
+
+    expect(data.user).toMatchObject({ id: 'user-1' });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the current user through the app refresh route when the access-token cookie is gone', async () => {
+    const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    vi.stubGlobal('document', { cookie: '' });
+    const fetch = vi.fn(async (url: string) => {
+      if (url === '/api/auth/refresh') {
+        return jsonResponse(200, { accessToken, user: { id: 'user-2' } });
+      }
+      return jsonResponse(401, {
+        error: ERROR_CODES.AUTH_UNAUTHORIZED,
+        message: 'No refresh token provided',
+        statusCode: 401,
+      });
+    });
+
+    const client = createBrowserClient({
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const { data, error } = await client.auth.getCurrentUser();
+
+    expect(error).toBeNull();
+    expect(data.user).toMatchObject({ id: 'user-2' });
+    expect(
+      fetch.mock.calls.filter(([url]: [string]) =>
+        String(url).startsWith('https://api.insforge.test')
+      )
+    ).toHaveLength(0);
+  });
+
   it('refreshes through the app route before a browser request when access token is missing', async () => {
     const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
     vi.stubGlobal('document', { cookie: '' });

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -267,6 +267,69 @@ describe('@insforge/sdk/ssr cookies', () => {
     ).toHaveLength(0);
   });
 
+  it('resolves the current user through the app refresh route when the access-token cookie is expired', async () => {
+    const expiredToken = jwtWithExp(Math.floor(Date.now() / 1000) - 60);
+    const freshToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {
+      cookie: `insforge_access_token=${encodeURIComponent(expiredToken)}`,
+    });
+    const fetch = vi.fn(async (url: string) => {
+      if (url === '/api/auth/refresh') {
+        return jsonResponse(200, { accessToken: freshToken, user: { id: 'user-3' } });
+      }
+      return jsonResponse(401, {
+        error: ERROR_CODES.AUTH_UNAUTHORIZED,
+        message: 'No refresh token provided',
+        statusCode: 401,
+      });
+    });
+
+    const client = createBrowserClient({
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const { data, error } = await client.auth.getCurrentUser();
+
+    expect(error).toBeNull();
+    expect(data.user).toMatchObject({ id: 'user-3' });
+    expect(
+      fetch.mock.calls.filter(([url]: [string]) =>
+        String(url).startsWith('https://api.insforge.test')
+      )
+    ).toHaveLength(0);
+  });
+
+  it('stops at the app refresh route when it reports no session', async () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', { cookie: '' });
+    const fetch = vi.fn(async () =>
+      jsonResponse(401, {
+        error: ERROR_CODES.AUTH_UNAUTHORIZED,
+        message: 'No refresh token provided',
+        statusCode: 401,
+      })
+    );
+
+    const client = createBrowserClient({
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const { data, error } = await client.auth.getCurrentUser();
+
+    expect(error).toBeNull();
+    expect(data.user).toBeNull();
+    // Falling through to the base client here would refresh against the
+    // InsForge origin, which cannot see the app's httpOnly cookie.
+    expect(
+      fetch.mock.calls.filter(([url]: [string]) =>
+        String(url).startsWith('https://api.insforge.test')
+      )
+    ).toHaveLength(0);
+  });
+
   it('refreshes through the app route before a browser request when access token is missing', async () => {
     const accessToken = jwtWithExp(Math.floor(Date.now() / 1000) + 900);
     vi.stubGlobal('document', { cookie: '' });

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -230,17 +230,26 @@ export function createBrowserClient(
     setAccessToken(token, event);
   };
 
-  // On a cold load the access token cookie may be absent or expired, and the
-  // base client's own refresh posts to the InsForge origin, which the app's
-  // httpOnly refresh cookie never reaches. Go through the app's refresh route
-  // first — it answers with the user, so a hydrating caller needs no second
-  // request.
+  // A missing or expiring access token on a cold load is the app route's
+  // business, and its answer is final. The base client would refresh against
+  // the InsForge origin, where the app-scoped httpOnly refresh cookie never
+  // arrives, so delegating after the route has already spoken only adds a
+  // request that is certain to 401. The route replies with the user, so
+  // hydrating from it costs nothing extra either.
   const getCurrentUser = client.auth.getCurrentUser.bind(client.auth);
   client.auth.getCurrentUser = async () => {
-    if (!accessToken) {
-      const refreshed = await refreshFromRoute().catch(() => null);
-      if (refreshed?.user) {
-        return { data: { user: refreshed.user }, error: null };
+    if (!accessToken || isJwtExpiredOrExpiring(accessToken, options.refreshLeewaySeconds)) {
+      try {
+        const refreshed = await refreshFromRoute();
+        return { data: { user: refreshed?.user ?? null }, error: null };
+      } catch (error) {
+        return {
+          data: { user: null },
+          error:
+            error instanceof InsForgeError
+              ? error
+              : new InsForgeError('Failed to refresh auth session', 500, ERROR_CODES.UNKNOWN_ERROR),
+        };
       }
     }
     return getCurrentUser();

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -231,17 +231,18 @@ export function createBrowserClient(
   };
 
   // A missing or expiring access token on a cold load is the app route's
-  // business, and its answer is final. The base client would refresh against
-  // the InsForge origin, where the app-scoped httpOnly refresh cookie never
-  // arrives, so delegating after the route has already spoken only adds a
-  // request that is certain to 401. The route replies with the user, so
-  // hydrating from it costs nothing extra either.
+  // business: the base client would refresh against the InsForge origin, where
+  // the app-scoped httpOnly refresh cookie never arrives. Once the route hands
+  // back a token the base method takes over and caches the user it resolves,
+  // so every later read is served from memory. When the route reports no
+  // session, that answer is final — delegating then would only add a refresh
+  // request that is certain to 401.
   const getCurrentUser = client.auth.getCurrentUser.bind(client.auth);
   client.auth.getCurrentUser = async () => {
     if (!accessToken || isJwtExpiredOrExpiring(accessToken, options.refreshLeewaySeconds)) {
+      let refreshed: AuthRefreshResponse | null;
       try {
-        const refreshed = await refreshFromRoute();
-        return { data: { user: refreshed?.user ?? null }, error: null };
+        refreshed = await refreshFromRoute();
       } catch (error) {
         return {
           data: { user: null },
@@ -250,6 +251,10 @@ export function createBrowserClient(
               ? error
               : new InsForgeError('Failed to refresh auth session', 500, ERROR_CODES.UNKNOWN_ERROR),
         };
+      }
+
+      if (!refreshed?.accessToken) {
+        return { data: { user: null }, error: null };
       }
     }
     return getCurrentUser();

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -230,6 +230,22 @@ export function createBrowserClient(
     setAccessToken(token, event);
   };
 
+  // On a cold load the access token cookie may be absent or expired, and the
+  // base client's own refresh posts to the InsForge origin, which the app's
+  // httpOnly refresh cookie never reaches. Go through the app's refresh route
+  // first — it answers with the user, so a hydrating caller needs no second
+  // request.
+  const getCurrentUser = client.auth.getCurrentUser.bind(client.auth);
+  client.auth.getCurrentUser = async () => {
+    if (!accessToken) {
+      const refreshed = await refreshFromRoute().catch(() => null);
+      if (refreshed?.user) {
+        return { data: { user: refreshed.user }, error: null };
+      }
+    }
+    return getCurrentUser();
+  };
+
   if (accessToken) {
     client.setAccessToken(accessToken);
   }

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -163,7 +163,14 @@ export function createBrowserClient(
       }
 
       accessToken = refreshBody.accessToken;
-      client?.setAccessToken(refreshBody.accessToken, AuthChangeEvent.TOKEN_REFRESHED);
+      // The route answers with the user as well as the token, and both are
+      // required above — so record a whole session. Storing only the token
+      // would leave `auth.getCurrentUser()` holding a token with no identity
+      // behind it, and it would go back to the network for one it already has.
+      client?.setSession(
+        { accessToken: refreshBody.accessToken, user: refreshBody.user },
+        AuthChangeEvent.TOKEN_REFRESHED
+      );
       return refreshBody as AuthRefreshResponse;
     })().finally(() => {
       sessionChecked = true;
@@ -232,11 +239,10 @@ export function createBrowserClient(
 
   // A missing or expiring access token on a cold load is the app route's
   // business: the base client would refresh against the InsForge origin, where
-  // the app-scoped httpOnly refresh cookie never arrives. Once the route hands
-  // back a token the base method takes over and caches the user it resolves,
-  // so every later read is served from memory. When the route reports no
-  // session, that answer is final — delegating then would only add a refresh
-  // request that is certain to 401.
+  // the app-scoped httpOnly refresh cookie never arrives. The route records a
+  // full session, so the base method below then answers from memory without a
+  // request of its own. When the route reports no session, that answer is
+  // final — delegating then would only add a refresh certain to 401.
   const getCurrentUser = client.auth.getCurrentUser.bind(client.auth);
   client.auth.getCurrentUser = async () => {
     if (!accessToken || isJwtExpiredOrExpiring(accessToken, options.refreshLeewaySeconds)) {

--- a/src/ssr/browser-client.ts
+++ b/src/ssr/browser-client.ts
@@ -162,6 +162,9 @@ export function createBrowserClient(
         return null;
       }
 
+      // Assigned here as well as by the wrapped setter below, because a
+      // refresh can run while the client is still being constructed — hence
+      // the optional call — and the captured token has to be right either way.
       accessToken = refreshBody.accessToken;
       // The route answers with the user as well as the token, and both are
       // required above — so record a whole session. Storing only the token
@@ -235,6 +238,16 @@ export function createBrowserClient(
   client.setAccessToken = (token: string | null, event) => {
     accessToken = token;
     setAccessToken(token, event);
+  };
+
+  // Both token entry points have to feed the captured token, not just one. A
+  // session handed in from outside is as current as one this client refreshed;
+  // if it did not land here, the read below would treat the token as missing
+  // and refresh over a session it had just been given.
+  const setSession = client.setSession.bind(client);
+  client.setSession = (session, event) => {
+    accessToken = session.accessToken;
+    setSession(session, event);
   };
 
   // A missing or expiring access token on a cold load is the app route's


### PR DESCRIPTION
## Summary

Closes #124

`createBrowserClient().auth.getCurrentUser()` never returned the user on a cold page load, even with a valid cookie pair.

`TokenManager.getSession()` returns null unless **both** the access token and the user are set, and `setAccessToken()` only ever sets the token. So on a fresh tab the token is hydrated from the readable `insforge_access_token` cookie but the user is not, `getSession()` is null, and `getCurrentUser()` falls through to `Auth.refreshSession()` — which posts to the InsForge origin. The httpOnly refresh cookie is scoped to the app's own domain, so it never rides along and the call answers `401 No refresh token provided`. Every cold load, forever.

## What changed

**`src/modules/auth/auth.ts`** — in browser mode, when an access token is held but no user, resolve the user with that token via `GET /api/auth/sessions/current` and cache it on the token manager, before falling back to the refresh. The probe passes `skipAuthRefresh` so a rejected token reaches this method's own 401 handling instead of the HTTP client refreshing against the InsForge origin behind it; a 401 there just means the token is stale, so the existing refresh path still runs. Extracted the request the server branch already made into `fetchCurrentUser()` so both paths share it.

The new branch sits inside the existing `typeof window !== 'undefined'` guard, so non-browser callers keep the "silent null" contract that `client.test.ts` pins down for `isServerMode: false`.

**`src/ssr/browser-client.ts`** — a missing *or expiring* access token is handled by the app's own refresh route rather than the base client's cross-origin one. That route answers with a token *and* the user it belongs to, and `refreshFromRoute()` already requires both, so its response is now recorded as a whole session rather than a bare token; the base method then answers from memory with no request of its own. When the route reports no session that answer is terminal, and a route refresh that throws surfaces its structured error — delegating in either case would only add a request that cannot carry the app-scoped refresh cookie.

**`src/client.ts`** — adds `setSession()` for a session established outside the SDK. `setAccessToken()` records a token with no user behind it, which is the same shape that caused this bug: a client holding a token but no identity. This is what lets the SSR refresh route store what it already knows. The browser client wraps both setters, so a session handed in from outside updates the token it tracks — otherwise the next read would treat the token as missing and refresh over a session it had just been given.

## Tests

Six cases added to `src/ssr/__tests__/ssr.test.ts`. All six fail against `main` (`fd1e7f5`) and pass here:

- cold load with a valid access-token cookie resolves the user, without touching the InsForge-origin refresh endpoint
- a second read is served from memory, not the network
- cold load with no access-token cookie resolves through `/api/auth/refresh`, and neither that read nor the next makes any InsForge-origin request
- cold load with an *expired* access-token cookie resolves the same way
- a session passed to `setSession()` is used as-is, with no refresh over the top of it
- when the app route reports no session, the read stops there with `{ user: null }` and makes no cross-origin call at all

## Verification

- `npx vitest run` — 218 passed (13 files)
- `npx tsc --noEmit` — clean
- `npx eslint` on the changed files — no errors (only pre-existing warnings)
- `npx prettier --check` on the changed files — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for synchronizing externally established sessions, including access tokens and user identity.
  * Improved server-rendered authentication to resolve and cache the current user during initial page loads.
* **Bug Fixes**
  * Improved handling of missing, expired, and refreshed sessions.
  * Prevented unnecessary authentication requests.
  * Added clearer behavior when no active session exists or session refresh fails.
* **Tests**
  * Expanded coverage for valid, missing, and expired sessions across browser and server-rendered authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->