### PR TITLE
feat(ssr): expose the email verification and password reset flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,38 @@ SSR browser clients do not exchange OAuth callbacks automatically. OAuth
 callbacks must be completed on the server so the refresh token lands in the
 httpOnly app cookie.
 
+The same helper covers the email flows. `resendVerificationEmail()`,
+`sendResetPasswordEmail()`, `exchangeResetPasswordToken()` and
+`resetPassword()` neither open nor close a session, so they write no cookies —
+they are here so a Server Action can run every auth flow through one client:
+
+```typescript
+// app/actions.ts
+'use server';
+
+import { cookies } from 'next/headers';
+import { createAuthActions } from '@insforge/sdk/ssr';
+
+export async function resetPassword(formData: FormData) {
+  const auth = createAuthActions({ cookies: await cookies() });
+
+  // Exchange the emailed code for a single-use reset token, then spend it.
+  const { data, error } = await auth.exchangeResetPasswordToken({
+    email: String(formData.get('email')),
+    code: String(formData.get('code')),
+  });
+  if (error || !data) {
+    return { error };
+  }
+
+  const result = await auth.resetPassword({
+    newPassword: String(formData.get('password')),
+    otp: data.token,
+  });
+  return { error: result.error };
+}
+```
+
 For Route Handlers, pass request cookies for reading the current session and
 response cookies for writing the next session:
 

--- a/SDK-REFERENCE.md
+++ b/SDK-REFERENCE.md
@@ -90,6 +90,13 @@ through a Server Action or Route Handler that can set cookies. Do not return
 raw auth responses from Server Actions; return only the user or app-specific
 safe fields.
 
+`createAuthActions()` also exposes the flows that carry no session —
+`resendVerificationEmail()`, `sendResetPasswordEmail()`,
+`exchangeResetPasswordToken()` and `resetPassword()` — so an SSR app can run
+every auth flow through one client. These write no cookies. Note that the
+session-bearing actions return `SafeAuthData`, which strips `accessToken` and
+`refreshToken`: check `data?.user` for success, not `data?.accessToken`.
+
 ```typescript
 // app/actions.ts
 'use server';

--- a/src/ssr/__tests__/ssr.test.ts
+++ b/src/ssr/__tests__/ssr.test.ts
@@ -532,6 +532,104 @@ describe('@insforge/sdk/ssr auth actions', () => {
     expect(cookies.values.get('insforge_refresh_token')).toBe(refreshToken);
   });
 
+  it('resends a verification email without touching cookies', async () => {
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://api.insforge.test/api/auth/email/send-verification');
+      expect(JSON.parse(String(init.body))).toEqual({ email: 'user@example.com' });
+      return jsonResponse(200, { success: true, message: 'Verification email sent' });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.resendVerificationEmail({ email: 'user@example.com' });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ success: true, message: 'Verification email sent' });
+    expect(cookies.set).not.toHaveBeenCalled();
+  });
+
+  it('sends a password reset email without touching cookies', async () => {
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://api.insforge.test/api/auth/email/send-reset-password');
+      expect(JSON.parse(String(init.body))).toEqual({ email: 'user@example.com' });
+      return jsonResponse(200, { success: true, message: 'Reset email sent' });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.sendResetPasswordEmail({ email: 'user@example.com' });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ success: true, message: 'Reset email sent' });
+    expect(cookies.set).not.toHaveBeenCalled();
+  });
+
+  it('exchanges a reset code for the reset token the caller needs', async () => {
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://api.insforge.test/api/auth/email/exchange-reset-password-token');
+      expect(JSON.parse(String(init.body))).toEqual({
+        email: 'user@example.com',
+        code: '123456',
+      });
+      return jsonResponse(200, { token: 'reset-token', expiresAt: '2026-01-01T00:00:00Z' });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.exchangeResetPasswordToken({
+      email: 'user@example.com',
+      code: '123456',
+    });
+
+    expect(result.error).toBeNull();
+    // A single-use reset credential, not a session token: the caller cannot
+    // finish the reset without it.
+    expect(result.data).toEqual({ token: 'reset-token', expiresAt: '2026-01-01T00:00:00Z' });
+    expect(cookies.set).not.toHaveBeenCalled();
+  });
+
+  it('resets the password without opening a session', async () => {
+    const cookies = cookieStore();
+    const fetch = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://api.insforge.test/api/auth/email/reset-password');
+      expect(JSON.parse(String(init.body))).toEqual({
+        newPassword: 'new-secret',
+        otp: 'reset-token',
+      });
+      return jsonResponse(200, { message: 'Password updated' });
+    });
+
+    const auth = createAuthActions({
+      cookies,
+      baseUrl: 'https://api.insforge.test',
+      anonKey: 'anon-key',
+      fetch: fetch as any,
+    });
+    const result = await auth.resetPassword({
+      newPassword: 'new-secret',
+      otp: 'reset-token',
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ message: 'Password updated' });
+    expect(cookies.set).not.toHaveBeenCalled();
+  });
+
   it('throws when auth actions cannot resolve a writable cookie store', () => {
     expect(() =>
       createAuthActions({

--- a/src/ssr/auth-actions.ts
+++ b/src/ssr/auth-actions.ts
@@ -48,9 +48,13 @@ export interface AuthActions {
   signInWithOAuth: InsForgeClient['auth']['signInWithOAuth'];
   signInWithIdToken: SafeAuthAction<InsForgeClient['auth']['signInWithIdToken']>;
   exchangeOAuthCode: SafeAuthAction<InsForgeClient['auth']['exchangeOAuthCode']>;
+  resendVerificationEmail: InsForgeClient['auth']['resendVerificationEmail'];
   verifyEmail: SafeAuthAction<InsForgeClient['auth']['verifyEmail']>;
   signInWithOtp: InsForgeClient['auth']['signInWithOtp'];
   verifyOtp: SafeAuthAction<InsForgeClient['auth']['verifyOtp']>;
+  sendResetPasswordEmail: InsForgeClient['auth']['sendResetPasswordEmail'];
+  exchangeResetPasswordToken: InsForgeClient['auth']['exchangeResetPasswordToken'];
+  resetPassword: InsForgeClient['auth']['resetPassword'];
   signOut: InsForgeClient['auth']['signOut'];
 }
 
@@ -156,6 +160,15 @@ export function createAuthActions(options: CreateAuthActionsOptions = {}): AuthA
       return toSafeAuthResult<InsForgeClient['auth']['exchangeOAuthCode']>(result);
     },
 
+    // The email-verification and password-reset senders, the reset-code
+    // exchange, and the reset itself neither open nor close a session, so
+    // there is nothing to write to the cookie store. The exchange hands back a
+    // single-use reset token rather than session credentials, and the caller
+    // needs it to complete the reset, so it is returned as-is.
+    resendVerificationEmail: async (request) => {
+      return createClient().auth.resendVerificationEmail(request);
+    },
+
     verifyEmail: async (request) => {
       const result = await createClient().auth.verifyEmail(request);
       persistSessionCookies(writeCookies, result.data, cookieSettings);
@@ -170,6 +183,18 @@ export function createAuthActions(options: CreateAuthActionsOptions = {}): AuthA
       const result = await createClient().auth.verifyOtp(request);
       persistSessionCookies(writeCookies, result.data, cookieSettings);
       return toSafeAuthResult<InsForgeClient['auth']['verifyOtp']>(result);
+    },
+
+    sendResetPasswordEmail: async (request) => {
+      return createClient().auth.sendResetPasswordEmail(request);
+    },
+
+    exchangeResetPasswordToken: async (request) => {
+      return createClient().auth.exchangeResetPasswordToken(request);
+    },
+
+    resetPassword: async (request) => {
+      return createClient().auth.resetPassword(request);
     },
 
     signOut: async () => {


### PR DESCRIPTION
## Summary

Closes #128

`createAuthActions()` is documented as the way to run auth flows from a Server Action, but `AuthActions` exposed only nine methods and none of the email flows. `resendVerificationEmail`, `sendResetPasswordEmail`, `exchangeResetPasswordToken` and `resetPassword` all exist on the root `Auth` class (`src/modules/auth/auth.ts:638-729`) and were simply never surfaced, so a Server Action calling `auth.resendVerificationEmail(...)` failed to compile and the reporter had to construct a second, plain client alongside the SSR one.

## What changed

**`src/ssr/auth-actions.ts`** — the four methods are added to `AuthActions` and delegate to the server client.

None of them open or close a session, so none write cookies: the two senders and the reset itself return `{ success, message }` / `{ message }`, and the code exchange returns `{ token, expiresAt }` — a single-use reset credential, not session credentials. That matches how the existing non-session actions (`signInWithOtp`, `signOut`) are typed and implemented, so they take the raw method type rather than `SafeAuthAction`, and the reset token is returned as-is because the caller cannot complete `resetPassword()` without it.

## Docs

The two files the issue names (`auth/ssr-integration.md`, `auth/sdk-integration.md`) are not in this repo, so the `accessToken`-check fix has to land wherever those are published — this repo's SSR examples already check `data?.user`. What is in scope here:

- `README.md` documents the newly available flows with a two-step password-reset Server Action.
- `SDK-REFERENCE.md` notes them, and states explicitly that session-bearing actions return `SafeAuthData` and should be checked via `data?.user`, not `data?.accessToken` — the misconception behind the second half of the issue.

## Tests

Four cases added to `src/ssr/__tests__/ssr.test.ts`, all four fail on `main` (`fd1e7f5`) and pass here — each asserts the endpoint and body, and that no cookie was written:

- resends a verification email
- sends a password reset email
- exchanges a reset code for the reset token the caller needs
- resets the password without opening a session

## Verification

- `npx vitest run` — 216 passed (13 files)
- `npx tsc --noEmit` — clean
- `npx eslint` on the changed files — no errors (only pre-existing warnings)
- `npx prettier --check` on the changed files — clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes email verification and password reset flows in SSR `AuthActions` so Server Actions can run them through one client. Previously `createAuthActions()` omitted these methods, causing compile-time failures; now they are available and preserve non-session behavior (no cookie writes).

- Adds `resendVerificationEmail`, `sendResetPasswordEmail`, `exchangeResetPasswordToken`, and `resetPassword` to `src/ssr/auth-actions.ts`; each delegates to the server client. `exchangeResetPasswordToken` returns `{ token, expiresAt }` and is not wrapped in `SafeAuthAction`.
- No session is opened or closed by these flows; they do not write cookies. This mirrors existing non-session actions.
- Docs: `README.md` shows an SSR two-step reset example using `createAuthActions` from `@insforge/sdk/ssr`. `SDK-REFERENCE.md` documents the new methods and clarifies that session-bearing actions should be checked via `data?.user`, not `data?.accessToken`.
- Tests: four additions verify the correct endpoints/body and that no cookies are written. No migration required; SSR callers can now invoke these methods directly via `createAuthActions()`.

<sup>Written for commit 7e3d46c5567894e389f5be8a9f4968b813ab916a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge-sdk-js/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

